### PR TITLE
chore(build): add steps to build and push image from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,13 @@ before_script:
   - export BRANCH="$TRAVIS_BRANCH"
 
 script:
-  - make provisioner-localpv-image
+  - make provisioner-localpv-image PROVISIONER_LOCALPV_IMAGE=provisioner-localpv-amd64
+
+after_success:
+  - make push PROVISIONER_LOCALPV_IMAGE=provisioner-localpv-amd64
 
 notifications:
   email:
     recipients:
     - kiran.mova@mayadata.io
+    - akhil.mohan@mayadata.io

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,11 @@ verify-src:
 # Specify the name for the binaries
 PROVISIONER_LOCALPV=provisioner-localpv
 
+# This variable is added specifically to build amd64 images from travis.
+# Once travis is deprecated, this field will be replaced by image name
+# used in Makefile.buildx.mk
+PROVISIONER_LOCALPV_IMAGE?=provisioner-localpv
+
 #Use this to build provisioner-localpv
 .PHONY: provisioner-localpv
 provisioner-localpv:
@@ -157,7 +162,7 @@ provisioner-localpv-image: provisioner-localpv
 	@echo "--> provisioner-localpv image "
 	@echo "-------------------------------"
 	@cp bin/provisioner-localpv/${PROVISIONER_LOCALPV} buildscripts/provisioner-localpv/
-	@cd buildscripts/provisioner-localpv && docker build -t ${IMAGE_ORG}/provisioner-localpv:${IMAGE_TAG} ${DBUILD_ARGS} . --no-cache
+	@cd buildscripts/provisioner-localpv && docker build -t ${IMAGE_ORG}/${PROVISIONER_LOCALPV_IMAGE}:${IMAGE_TAG} ${DBUILD_ARGS} . --no-cache
 	@rm buildscripts/provisioner-localpv/${PROVISIONER_LOCALPV}
 
 .PHONY: license-check
@@ -173,6 +178,10 @@ license-check:
 	@echo "--> Done checking license."
 	@echo
 
+
+.PHONY: push
+push:
+	DIMAGE=${IMAGE_ORG}/${PROVISIONER_LOCALPV_IMAGE} ./buildscripts/push.sh
 
 # include the buildx recipes
 include Makefile.buildx.mk

--- a/buildscripts/push.sh
+++ b/buildscripts/push.sh
@@ -46,3 +46,91 @@ if [[ ${BUILDX} ]]; then
   exit 0
 fi
 
+# The below steps are required for pushing arch specific images.
+# This steps will be removed eventually in favour of buildx-push
+
+# Generate a unique tag based on the commit and tag
+BUILD_ID=$(git describe --tags --always)
+
+# Determine the current branch
+CURRENT_BRANCH=""
+if [ -z ${BRANCH} ];
+then
+  CURRENT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
+else
+  CURRENT_BRANCH=${BRANCH}
+fi
+
+#Depending on the branch where builds are generated,
+# set the tag CI (fixed) and build tags.
+BUILD_TAG="${CURRENT_BRANCH}-${BUILD_ID}"
+CI_TAG="${CURRENT_BRANCH}-ci"
+if [ ${CURRENT_BRANCH} = "develop" ]; then
+  CI_TAG="ci"
+fi
+
+echo "Set the fixed ci image tag as: ${CI_TAG}"
+echo "Set the build/unique image tag as: ${BUILD_TAG}"
+
+function TagAndPushImage() {
+  REPO="$1"
+  # Trim the `v` from the TAG if it exists
+  # Example: v1.10.0 maps to 1.10.0
+  # Example: 1.10.0 maps to 1.10.0
+  # Example: v1.10.0-custom maps to 1.10.0-custom
+  TAG="${2#v}"
+
+  #Add an option to specify a custom TAG_SUFFIX
+  #via environment variable. Default is no tag.
+  #Example suffix could be "-debug" of "-dev"
+  IMAGE_URI="${REPO}:${TAG}${TAG_SUFFIX}";
+  sudo docker tag ${IMAGEID} ${IMAGE_URI};
+  echo " push ${IMAGE_URI}";
+  sudo docker push ${IMAGE_URI};
+}
+
+
+if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ];
+then
+  sudo docker login -u "${DNAME}" -p "${DPASS}";
+
+  # Push CI tagged image - :ci or :branch-ci
+  TagAndPushImage "${DIMAGE}" "${CI_TAG}"
+
+  # Push unique tagged image - :master-<uuid> or :branch-<uuid>
+  # This unique/build image will be pushed to corresponding ci repo.
+  TagAndPushImage "${DIMAGE}-ci" "${BUILD_TAG}"
+
+  if [ ! -z "${RELEASE_TAG}" ] ;
+  then
+    # Push with different tags if tagged as a release
+    # When github is tagged with a release, then Travis will
+    # set the release tag in env RELEASE_TAG
+    TagAndPushImage "${DIMAGE}" "${RELEASE_TAG}"
+    TagAndPushImage "${DIMAGE}" "latest"
+  fi;
+else
+  echo "No docker credentials provided. Skip uploading ${DIMAGE} to docker hub";
+fi;
+
+# Push ci image to quay.io for security scanning
+if [ ! -z "${QNAME}" ] && [ ! -z "${QPASS}" ];
+then
+  sudo docker login -u "${QNAME}" -p "${QPASS}" quay.io;
+
+  # Push CI tagged image - :ci or :branch-ci
+  TagAndPushImage "quay.io/${DIMAGE}" "${CI_TAG}"
+
+  if [ ! -z "${RELEASE_TAG}" ] ;
+  then
+    # Push with different tags if tagged as a release
+    # When github is tagged with a release, then Travis will
+    # set the release tag in env RELEASE_TAG
+    # Trim the `v` from the RELEASE_TAG if it exists
+    TagAndPushImage "quay.io/${DIMAGE}" "${RELEASE_TAG}"
+    TagAndPushImage "quay.io/${DIMAGE}" "latest"
+  fi;
+else
+  echo "No docker credentials provided. Skip uploading ${DIMAGE} to quay";
+fi;
+


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**Why is this PR required? What issue does it fix?**:
Enable pushing amd64 images from travis as mentioned [here](https://github.com/openebs/openebs/discussions/3299#discussioncomment-124487)

**What this PR does?**:
- makes image name configurable when not using buildx
- enable pushing amd64 image to docker hub and quay
- build and push amd64 image from travis

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: