### PR TITLE
feat(helm): add github action for chart test and release

### DIFF
--- a/.github/workflows/chart-lint-test.yml
+++ b/.github/workflows/chart-lint-test.yml
@@ -1,0 +1,52 @@
+name: Chart Lint and Test
+
+on:
+  push:
+    paths:
+      - 'deploy/helm/**'
+    branches:
+      - develop
+  pull_request:
+    paths:
+      - 'deploy/helm/**'
+    branches:
+      - develop
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config ct.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config ct.yaml
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.0.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install --config ct.yaml

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,6 +16,8 @@ name: ci
 
 on:
   pull_request:
+    paths-ignore:
+      - 'deploy/helm/**'
     branches:
       # on pull requests to develop and release branches
       - develop

--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -1,0 +1,38 @@
+name: Release Charts
+
+on:
+  push:
+    paths:
+      - 'deploy/helm/**'
+    branches:
+      - develop
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
+
+      - name: Add dependency chart repos
+        run: |
+          helm repo add openebs-ndm https://openebs.github.io/node-disk-manager
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.1.0
+        env:
+          CR_TOKEN: "${{ secrets.CR_TOKEN }}"
+        with:
+          charts_dir: deploy/helm

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,6 @@
+# See https://github.com/helm/chart-testing#configuration
+remote: origin
+target-branch: develop
+chart-dirs:
+  - deploy/helm
+helm-extra-args: --timeout=500s


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

## Pull Request template

**What this PR does?**:

This PR adds github action CI for dynamic localpv provisioner helm chart lint, test and release.

**Note:** The cStor helm charts will reside in a directory structure: `deploy/charts`

The following are the details of changes : 
1. Adds `Chart Lint and Test` action to test and lint the chart changes. 
- This action is only triggered if there is any change in the content of `deploy/charts` directory.

2. Modifies the existing `Go` action.
- As a result of the modification, the action will not run for pull requests if there are changes in the `deploy/charts` directory.

3. Adds a `Release Charts` action to release the helm chart. 
- This action triggers only when the push in against `develop` and there is a change in the content of `deploy/charts` directory.
