### PR TITLE
chore(lint): Fixing lint found on goreportcard.com

### DIFF
--- a/cmd/provisioner-localpv/app/helper_blockdevice.go
+++ b/cmd/provisioner-localpv/app/helper_blockdevice.go
@@ -113,7 +113,7 @@ func (p *Provisioner) createBlockDeviceClaim(blkDevOpts *HelperBlockDeviceOption
 	bdcName := "bdc-" + blkDevOpts.name
 
 	//Check if the BDC is already created. This can happen
-	//if the previous reconcilation of PVC-PV, resulted in
+	//if the previous reconciliation of PVC-PV, resulted in
 	//creating a BDC, but BD was not yet available for 60+ seconds
 	_, err := blockdeviceclaim.NewKubeClient().
 		WithNamespace(p.namespace).

--- a/cmd/provisioner-localpv/app/helper_hostpath.go
+++ b/cmd/provisioner-localpv/app/helper_hostpath.go
@@ -199,8 +199,14 @@ func (p *Provisioner) launchPod(config podConfig) (*corev1.Pod, error) {
 		).
 		Build()
 
+	if err != nil {
+		return nil, err
+	}
+
+	var hPod *corev1.Pod
+
 	//Launch the helper pod.
-	hPod, err := p.kubeClient.CoreV1().Pods(p.namespace).Create(helperPod)
+	hPod, err = p.kubeClient.CoreV1().Pods(p.namespace).Create(helperPod)
 	return hPod, err
 }
 

--- a/pkg/kubernetes/api/core/v1/pod/pod.go
+++ b/pkg/kubernetes/api/core/v1/pod/pod.go
@@ -73,7 +73,7 @@ func (l PredicateList) all(p *Pod) bool {
 	return true
 }
 
-// IsRunning retuns true if the pod is in running
+// IsRunning returns true if the pod is in running
 // state
 func (p *Pod) IsRunning() bool {
 	return p.object.Status.Phase == "Running"
@@ -87,7 +87,7 @@ func IsRunning() Predicate {
 	}
 }
 
-// IsCompleted retuns true if the pod is in completed
+// IsCompleted returns true if the pod is in completed
 // state
 func (p *Pod) IsCompleted() bool {
 	return p.object.Status.Phase == "Succeeded"
@@ -116,7 +116,7 @@ func HasLabels(keyValuePair map[string]string) Predicate {
 	}
 }
 
-// HasLabel return true if provided lable
+// HasLabel return true if provided label
 // key and value are present in the the provided PodList
 // instance
 func (p *Pod) HasLabel(key, value string) bool {

--- a/pkg/kubernetes/api/core/v1/podtemplatespec/podtemplatespec.go
+++ b/pkg/kubernetes/api/core/v1/podtemplatespec/podtemplatespec.go
@@ -214,18 +214,6 @@ func (b *Builder) WithNodeSelectorNew(nodeselectors map[string]string) *Builder 
 	return b
 }
 
-func (b *Builder) WithNodeSelectorByValue(nodeselectors map[string]string) *Builder {
-	// copy of original map
-	newnodeselectors := map[string]string{}
-	for key, value := range nodeselectors {
-		newnodeselectors[key] = value
-	}
-
-	// override
-	b.podtemplatespec.Object.Spec.NodeSelector = newnodeselectors
-	return b
-}
-
 // WithServiceAccountName sets the ServiceAccountnNme field of podtemplatespec
 func (b *Builder) WithServiceAccountName(serviceAccountnNme string) *Builder {
 	if len(serviceAccountnNme) == 0 {

--- a/pkg/kubernetes/api/core/v1/podtemplatespec/podtemplatespec_test.go
+++ b/pkg/kubernetes/api/core/v1/podtemplatespec/podtemplatespec_test.go
@@ -99,7 +99,7 @@ func TestBuildWithAnnotations(t *testing.T) {
 		builder     *Builder
 		expectErr   bool
 	}{
-		"Test Builderwith annotations": {
+		"Test Builder with annotations": {
 			annotations: map[string]string{"persistent-volume": "PV",
 				"application": "percona"},
 			builder: &Builder{podtemplatespec: &PodTemplateSpec{
@@ -135,7 +135,7 @@ func TestBuildWithAnnotationsNew(t *testing.T) {
 		builder     *Builder
 		expectErr   bool
 	}{
-		"Test Builderwith annotations": {
+		"Test Builder with annotations": {
 			annotations: map[string]string{"persistent-volume": "PV",
 				"application": "percona"},
 			builder: &Builder{podtemplatespec: &PodTemplateSpec{
@@ -171,7 +171,7 @@ func TestBuildWithLabels(t *testing.T) {
 		builder   *Builder
 		expectErr bool
 	}{
-		"Test Builderwith labels": {
+		"Test Builder with labels": {
 			labels: map[string]string{"persistent-volume": "PV",
 				"application": "percona"},
 			builder: &Builder{podtemplatespec: &PodTemplateSpec{
@@ -207,7 +207,7 @@ func TestBuildWithLabelsNew(t *testing.T) {
 		builder   *Builder
 		expectErr bool
 	}{
-		"Test Builderwith labels": {
+		"Test Builder with labels": {
 			labels: map[string]string{"persistent-volume": "PV",
 				"application": "percona"},
 			builder: &Builder{podtemplatespec: &PodTemplateSpec{


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
This fixes lint issues as discovered by https://goreportcard.com/report/github.com/openebs/dynamic-localpv-provisioner. 

**What this PR does?**:
1. Fixes typos in /cmd/provisioner-localpv/app/helper_blockdevice.go
    Fixes typos in /pkg/kubernetes/api/core/v1/pod/pod.go
2. Ran `go fmt` on /pkg/kubernetes/api/core/v1/podtemplatespec/podtemplatespec_test.go
    Ran `go fmt` on /pkg/kubernetes/api/core/v1/container/container_test.go
3. Removes unused method Builder.WithNodeSelectorByValue in /pkg/kubernetes/api/core/v1/podtemplatespec/podtemplatespec.go
4. Fixes ineffassign for variable 'err' in /cmd/provisioner-localpv/app/helper_hostpath.go


**Does this PR require any upgrade changes?**: 
No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:
N/A

**Any additional information for your reviewer?** : 
Assignment at https://github.com/openebs/dynamic-localpv-provisioner/blob/5d1055a22b35dd153407442ce90adeb73d90cf1b/cmd/provisioner-localpv/app/helper_hostpath.go#L203 throws error because of insufficient parameters.

Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>