### PR TITLE
fix(pre-upgrade): Removed error return when no BDC is found for a PV

### DIFF
--- a/cmd/provisioner-localpv/app/backward_compatability.go
+++ b/cmd/provisioner-localpv/app/backward_compatability.go
@@ -24,6 +24,7 @@ import (
 	mconfig "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
 )
 
 // This function performs the preupgrade related tasks for 1.0 to 1.1
@@ -52,7 +53,7 @@ func addLocalPVFinalizerOnAssociatedBDCs(kubeClient *clientset.Clientset) error 
 			// to 'Retain' and the BDCs have been manually removed
 			// Ref: github.com/openebs/openebs/issues/3363
 			// TODO: Clean this part of the code up a bit.
-			errors.Wrapf(err, "Warning: failed to get bdc %v", bdcName)
+			klog.Warningf("failed to get bdc %v", bdcName)
 			continue
 		}
 

--- a/cmd/provisioner-localpv/app/backward_compatability.go
+++ b/cmd/provisioner-localpv/app/backward_compatability.go
@@ -48,7 +48,12 @@ func addLocalPVFinalizerOnAssociatedBDCs(kubeClient *clientset.Clientset) error 
 		bdcObj, err := blockdeviceclaim.NewKubeClient().WithNamespace(getOpenEBSNamespace()).
 			Get(bdcName, metav1.GetOptions{})
 		if err != nil {
-			return errors.Wrapf(err, "failed to get bdc %v", bdcName)
+			// BDCs may not exist if the PV reclaimPolicy is set
+			// to 'Retain' and the BDCs have been manually removed
+			// Ref: github.com/openebs/openebs/issues/3363
+			// TODO: Clean this part of the code up a bit.
+			errors.Wrapf(err, "Warning: failed to get bdc %v", bdcName)
+			continue
 		}
 
 		// Add finalizer only if deletionTimestamp is not set


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

**Why is this PR required? What issue does it fix?**:
This prevents the provisioner from crashing because of error returns throughout the stack if no BDC is found for a PV with `openebs.io/cas-type=local-device` label, when trying to add finalizers to BDCs created pre-OpenEBS v1.1.
Fixes https://github.com/openebs/openebs/issues/3363

**What this PR does?**:
Returns no error, and simply ignores the PVs with the above characteristics. Logs the incident as a warning.

**Does this PR require any upgrade changes?**:
No.