### PR TITLE
chore(docs): Add quickstart guide and helm chart update

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ differences include:
 
 ## Install
 
-Please refer to our documentation at [OpenEBS Documentation](http://docs.openebs.io/).
+Please refer to our [Quickstart](https://github.com/openebs/dynamic-localpv-provisioner/tree/develop/docs/quickstart.md) and the [OpenEBS Documentation](http://docs.openebs.io/).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ differences include:
 
 ## Install
 
-Please refer to our [Quickstart](https://github.com/openebs/dynamic-localpv-provisioner/tree/develop/docs/quickstart.md) and the [OpenEBS Documentation](http://docs.openebs.io/).
+Please refer to our [Quickstart](https://github.com/openebs/dynamic-localpv-provisioner/blob/develop/docs/quickstart.md) and the [OpenEBS Documentation](http://docs.openebs.io/).
 
 ## Contributing
 

--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for OpenEBS Dynamic Local PV. For instructions to instal
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.8.0
+version: 2.8.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 2.8.0

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -33,7 +33,7 @@ Please visit the [link](https://openebs.github.io/dynamic-localpv-provisioner/) 
 
 ```console
 # Helm
-$ helm install [RELEASE_NAME] openebs-localpv/localpv-provisioner
+$ helm install [RELEASE_NAME] openebs-localpv/localpv-provisioner --namespace [NAMESPACE]
 ```
 
 _See [configuration](#configuration) below._
@@ -57,7 +57,7 @@ _See [helm dependency](https://helm.sh/docs/helm/helm_dependency/) for command d
 
 ```console
 # Helm
-$ helm uninstall [RELEASE_NAME]
+$ helm uninstall [RELEASE_NAME] --namespace [NAMESPACE]
 ```
 
 This removes all the Kubernetes components associated with the chart and deletes the release.
@@ -68,13 +68,25 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 
 ```console
 # Helm
-$ helm upgrade [RELEASE_NAME] [CHART] --install
+$ helm upgrade [RELEASE_NAME] [CHART] --install --namespace [NAMESPACE]
 ```
 
 
 ## Configuration
 
-The following table lists the configurable parameters of the OpenEBS LocalPV Provisioner chart and their default values.
+The following table lists the configurable parameters of the OpenEBS Dynamic LocalPV Provisioner chart and their default values.
+
+You can modify different parameters by specifying the desired value in the `helm install` command by using the `--set` and/or the `--set-string` flag(s). You can modify the parameters of the [Node Disk Manager chart](https://openebs.github.io/node-disk-manager) by adding `openebs-ndm` before the desired parameter in the `helm install` command.
+
+In the following sample command we modify `deviceClass.fsType` from the localpv-provisioner chart and `ndm.nodeSelector` from the openebs-ndm chart to only schedule openebs-ndm DaemonSet pods on nodes labelled with `openebs.io/data-plane=true`. We also enable the 'Use OS-disk' feature gate using the `featureGates.UseOSDisk.enabled` parameter from the openebs-ndm chart.
+
+
+```console
+helm install openebs-localpv openebs-localpv/localpv-provisioner --namespace openebs --create-namespace \
+	--set-string deviceClass.fstype="xfs" \
+	--set-string openebs-ndm.ndm.nodeSelector."openebs\.io/data-plane"=true \
+	--set openebs-ndm.featureGates.UseOSDisk.enabled=true
+```
 
 | Parameter                                   | Description                                   | Default                                   |
 | ------------------------------------------- | --------------------------------------------- | ----------------------------------------- |
@@ -100,23 +112,22 @@ The following table lists the configurable parameters of the OpenEBS LocalPV Pro
 | `localpv.healthCheck.periodSeconds`         | How often to perform the liveness probe           | `60`                            |
 | `localpv.replicas`                          | No. of LocalPV Provisioner replica                | `1`                             |
 | `localpv.enableLeaderElection`              | Enable leader election                            | `true`                          |
-| `localpv.basePath`                          | BasePath for hostPath volumes on Nodes            | `"/var/openebs/local"`          |
+| `localpv.basePath`                          | Default value of BasePath for hostPath volumes    | `"/var/openebs/local"`          |
 | `localpv.affinity`                          | LocalPV Provisioner pod affinity                  | `{}`                            |
 | `helperPod.image.registry`                  | Registry for helper image                         | `""`                            |
 | `helperPod.image.repository`                | Image for helper pod                              | `"openebs/linux-utils"`         |
 | `helperPod.image.pullPolicy`                | Pull policy for helper pod                        | `"IfNotPresent"`                |
 | `helperPod.image.tag`                       | Image tag for helper image                        | `2.8.0`                         |
+| `hostpathClass.basePath`                    | BasePath for openebs-hostpath storageClass        | `"/var/openebs/local"`          |
 | `rbac.create`                               | Enable RBAC Resources                             | `true`                          |
 | `rbac.pspEnabled`                           | Create pod security policy resources              | `false`                         |
 | `openebsNDM.enabled`                        | Install openebs NDM dependency                    | `true`                          |
 
 
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
-
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-helm install <release-name> -f values.yaml --namespace openebs localpv-provisioner
+helm install <release-name> -f values.yaml --namespace openebs openebs-localpv/localpv-provisioner
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -95,7 +95,7 @@ helm install openebs-localpv openebs-localpv/localpv-provisioner --namespace ope
 | `release.version`                           | LocalPV Provisioner release version               | `2.8.0`                         |
 | `analytics.enabled`                         | Enable sending stats to Google Analytics          | `true`                          |
 | `analytics.pingInterval`                    | Duration(hours) between sending ping stat         | `24h`                           |
-| `deviceClass.blockDeviceTag`                | Value of 'openebs.io/block-device-tag' BD label   | `""`                            |
+| `deviceClass.blockDeviceTag`                | Value of `openebs.io/block-device-tag` BD label   | `""`                            |
 | `deviceClass.enabled`                       | Enables creation of default Device StorageClass   | `true`                          |
 | `deviceClass.fsType`                        | Filesystem type for openebs-device StorageClass   | `"ext4"`                        |
 | `deviceClass.isDefaultClass`                | Make openebs-device the default StorageClass      | `"false"`                       |
@@ -107,9 +107,8 @@ helm install openebs-localpv openebs-localpv/localpv-provisioner --namespace ope
 | `hostpathClass.basePath`                    | BasePath for openebs-hostpath StorageClass        | `"/var/openebs/local"`          |
 | `hostpathClass.enabled`                     | Enables creation of default Hostpath StorageClass | `true`                          |
 | `hostpathClass.isDefaultClass`              | Make openebs-hostpath the default StorageClass    | `"false"`                       |
-| `hostpathClass.nodeAffinityLabel`           | Custom node label key to uniquely ID nodes        | `""`                            |
+| `hostpathClass.nodeAffinityLabel`           | Custom node label key to uniquely identify nodes. `kubernetes.io/hostname` is the default label key for node selection. | `""`                            |
 | `hostpathClass.reclaimPolicy`               | ReclaimPolicy for Hostpath PVs                    | `"Delete"`                      |
-
 | `imagePullSecrets`                          | Provides image pull secrect                       | `""`                            |
 | `localpv.enabled`                           | Enable LocalPV Provisioner                        | `true`                          |
 | `localpv.image.registry`                    | Registry for LocalPV Provisioner image            | `""`                            |

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -48,6 +48,8 @@ By default this chart installs additional, dependent charts:
 |------------|------|---------|
 | https://openebs.github.io/node-disk-manager | openebs-ndm | 1.4.0 |
 
+**Note:** Find detailed Node Disk Manager Helm chart configuration options [here](https://github.com/openebs/node-disk-manager/blob/master/deploy/helm/charts/README.md).
+
 
 To disable the dependency during installation, set `openebsNDM.enabled` to `false`.
 

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -112,7 +112,6 @@ helm install openebs-localpv openebs-localpv/localpv-provisioner --namespace ope
 | `localpv.healthCheck.periodSeconds`         | How often to perform the liveness probe           | `60`                            |
 | `localpv.replicas`                          | No. of LocalPV Provisioner replica                | `1`                             |
 | `localpv.enableLeaderElection`              | Enable leader election                            | `true`                          |
-| `localpv.basePath`                          | Default value of BasePath for hostPath volumes    | `"/var/openebs/local"`          |
 | `localpv.affinity`                          | LocalPV Provisioner pod affinity                  | `{}`                            |
 | `helperPod.image.registry`                  | Registry for helper image                         | `""`                            |
 | `helperPod.image.repository`                | Image for helper pod                              | `"openebs/linux-utils"`         |
@@ -124,7 +123,7 @@ helm install openebs-localpv openebs-localpv/localpv-provisioner --namespace ope
 | `openebsNDM.enabled`                        | Install openebs NDM dependency                    | `true`                          |
 
 
-Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+A YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
 helm install <release-name> -f values.yaml --namespace openebs openebs-localpv/localpv-provisioner

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -33,7 +33,7 @@ Please visit the [link](https://openebs.github.io/dynamic-localpv-provisioner/) 
 
 ```console
 # Helm
-$ helm install [RELEASE_NAME] openebs-localpv/localpv-provisioner --namespace [NAMESPACE]
+helm install [RELEASE_NAME] openebs-localpv/localpv-provisioner --namespace [NAMESPACE] --create-namespace
 ```
 
 _See [configuration](#configuration) below._
@@ -59,7 +59,7 @@ _See [helm dependency](https://helm.sh/docs/helm/helm_dependency/) for command d
 
 ```console
 # Helm
-$ helm uninstall [RELEASE_NAME] --namespace [NAMESPACE]
+helm uninstall [RELEASE_NAME] --namespace [NAMESPACE]
 ```
 
 This removes all the Kubernetes components associated with the chart and deletes the release.
@@ -70,7 +70,7 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 
 ```console
 # Helm
-$ helm upgrade [RELEASE_NAME] [CHART] --install --namespace [NAMESPACE]
+helm upgrade [RELEASE_NAME] [CHART] --install --namespace [NAMESPACE]
 ```
 
 
@@ -85,7 +85,7 @@ In the following sample command we modify `deviceClass.fsType` from the localpv-
 
 ```console
 helm install openebs-localpv openebs-localpv/localpv-provisioner --namespace openebs --create-namespace \
-	--set-string deviceClass.fstype="xfs" \
+	--set-string deviceClass.fsType="xfs" \
 	--set-string openebs-ndm.ndm.nodeSelector."openebs\.io/data-plane"=true \
 	--set openebs-ndm.featureGates.UseOSDisk.enabled=true
 ```
@@ -95,6 +95,21 @@ helm install openebs-localpv openebs-localpv/localpv-provisioner --namespace ope
 | `release.version`                           | LocalPV Provisioner release version               | `2.8.0`                         |
 | `analytics.enabled`                         | Enable sending stats to Google Analytics          | `true`                          |
 | `analytics.pingInterval`                    | Duration(hours) between sending ping stat         | `24h`                           |
+| `deviceClass.blockDeviceTag`                | Value of 'openebs.io/block-device-tag' BD label   | `""`                            |
+| `deviceClass.enabled`                       | Enables creation of default Device StorageClass   | `true`                          |
+| `deviceClass.fsType`                        | Filesystem type for openebs-device StorageClass   | `"ext4"`                        |
+| `deviceClass.isDefaultClass`                | Make openebs-device the default StorageClass      | `"false"`                       |
+| `deviceClass.reclaimPolicy`                 | ReclaimPolicy for Device PVs                      | `"Delete"`                      |
+| `helperPod.image.registry`                  | Registry for helper image                         | `""`                            |
+| `helperPod.image.repository`                | Image for helper pod                              | `"openebs/linux-utils"`         |
+| `helperPod.image.pullPolicy`                | Pull policy for helper pod                        | `"IfNotPresent"`                |
+| `helperPod.image.tag`                       | Image tag for helper image                        | `2.8.0`                         |
+| `hostpathClass.basePath`                    | BasePath for openebs-hostpath StorageClass        | `"/var/openebs/local"`          |
+| `hostpathClass.enabled`                     | Enables creation of default Hostpath StorageClass | `true`                          |
+| `hostpathClass.isDefaultClass`              | Make openebs-hostpath the default StorageClass    | `"false"`                       |
+| `hostpathClass.nodeAffinityLabel`           | Custom node label key to uniquely ID nodes        | `""`                            |
+| `hostpathClass.reclaimPolicy`               | ReclaimPolicy for Hostpath PVs                    | `"Delete"`                      |
+
 | `imagePullSecrets`                          | Provides image pull secrect                       | `""`                            |
 | `localpv.enabled`                           | Enable LocalPV Provisioner                        | `true`                          |
 | `localpv.image.registry`                    | Registry for LocalPV Provisioner image            | `""`                            |
@@ -115,14 +130,9 @@ helm install openebs-localpv openebs-localpv/localpv-provisioner --namespace ope
 | `localpv.replicas`                          | No. of LocalPV Provisioner replica                | `1`                             |
 | `localpv.enableLeaderElection`              | Enable leader election                            | `true`                          |
 | `localpv.affinity`                          | LocalPV Provisioner pod affinity                  | `{}`                            |
-| `helperPod.image.registry`                  | Registry for helper image                         | `""`                            |
-| `helperPod.image.repository`                | Image for helper pod                              | `"openebs/linux-utils"`         |
-| `helperPod.image.pullPolicy`                | Pull policy for helper pod                        | `"IfNotPresent"`                |
-| `helperPod.image.tag`                       | Image tag for helper image                        | `2.8.0`                         |
-| `hostpathClass.basePath`                    | BasePath for openebs-hostpath storageClass        | `"/var/openebs/local"`          |
+| `openebsNDM.enabled`                        | Install openebs NDM dependency                    | `true`                          |
 | `rbac.create`                               | Enable RBAC Resources                             | `true`                          |
 | `rbac.pspEnabled`                           | Create pod security policy resources              | `false`                         |
-| `openebsNDM.enabled`                        | Install openebs NDM dependency                    | `true`                          |
 
 
 A YAML file that specifies the values for the parameters can be provided while installing the chart. For example,

--- a/deploy/helm/charts/templates/NOTES.txt
+++ b/deploy/helm/charts/templates/NOTES.txt
@@ -6,7 +6,7 @@ Use `kubectl get bd -n {{ .Release.Namespace }}` to list the
 blockdevices attached to the Kubernetes cluster nodes.
 
 Get started with the Dynamic LocalPV Provisioner Quickstart guide at:
-https://github.com/openebs/dynamic-localpv-provisioner/tree/master/docs/quickstart.md
+https://github.com/openebs/dynamic-localpv-provisioner/blob/develop/docs/quickstart.md
 
 For more information, visit our Slack at https://openebs.io/community or view 
 the OpenEBS documentation online at https://docs.openebs.io.

--- a/deploy/helm/charts/templates/NOTES.txt
+++ b/deploy/helm/charts/templates/NOTES.txt
@@ -1,8 +1,12 @@
-The OpenEBS localPV Provisioner has been installed check its status by running:
+The OpenEBS Dynamic LocalPV Provisioner has been installed.
+Check its status by running:
 $ kubectl get pods -n {{ .Release.Namespace }}
 
-Use `kubectl get bd -n {{ .Release.Namespace }} ` to see the list of 
+Use `kubectl get bd -n {{ .Release.Namespace }}` to list the 
 blockdevices attached to the Kubernetes cluster nodes.
 
+Get started with the Dynamic LocalPV Provisioner Quickstart guide at:
+https://github.com/openebs/dynamic-localpv-provisioner/tree/master/docs/quickstart.md
+
 For more information, visit our Slack at https://openebs.io/community or view 
-the documentation online at http://docs.openebs.io/.
+the OpenEBS documentation online at https://docs.openebs.io.

--- a/deploy/helm/charts/templates/device-class.yaml
+++ b/deploy/helm/charts/templates/device-class.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deviceClass.enabled }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -23,3 +24,4 @@ metadata:
 provisioner: openebs.io/local
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: {{ .Values.deviceClass.reclaimPolicy }}
+{{- end }}

--- a/deploy/helm/charts/templates/device-class.yaml
+++ b/deploy/helm/charts/templates/device-class.yaml
@@ -6,10 +6,8 @@ metadata:
   annotations:
     openebs.io/cas-type: local
     cas.openebs.io/config: |
-{{- if .Values.deviceClass.fsType }}
       - name: StorageType
-        value: {{ .Values.deviceClass.storageType }}
-{{- end }}
+        value: "device"
 {{- if .Values.deviceClass.fsType }}
       - name: FSType
         value: {{ .Values.deviceClass.fsType }}

--- a/deploy/helm/charts/templates/hostpath-class.yaml
+++ b/deploy/helm/charts/templates/hostpath-class.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.hostpathClass.enabled }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -23,3 +24,4 @@ metadata:
 provisioner: openebs.io/local
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: {{ .Values.hostpathClass.reclaimPolicy }}
+{{- end }}

--- a/deploy/helm/charts/templates/hostpath-class.yaml
+++ b/deploy/helm/charts/templates/hostpath-class.yaml
@@ -6,10 +6,8 @@ metadata:
   annotations:
     openebs.io/cas-type: local
     cas.openebs.io/config: |
-{{- if .Values.hostpathClass.storageType }}
       - name: StorageType
-        value: {{ .Values.hostpathClass.storageType }}
-{{- end }}
+        value: "hostpath"
 {{- if .Values.hostpathClass.basePath }}
       - name: BasePath
         value: {{ .Values.hostpathClass.basePath }}

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -75,13 +75,14 @@ serviceAccount:
   name:
 
 deviceClass:
-  # Defines name of storage class.
+  # Name of default device StorageClass.
   name: openebs-device
+  # If true, enables creation of the openebs-device StorageClass
+  enabled: true
   # Available reclaim policies: Delete/Retain, defaults: Delete.
   reclaimPolicy: Delete
-  # set as default class
+  # If true, sets the openebs-device StorageClass as the default StorageClass
   isDefaultClass: false
-  storageType: "device"
   fsType: "ext4"
   # Label block devices in the cluster that you would like the openEBS localPV
   # Provisioner to pick up those specific block devices available on the node.
@@ -90,11 +91,14 @@ deviceClass:
   blockDeviceTag: ""
 
 hostpathClass:
+  # Name of the default hostpath StorageClass
   name: openebs-hostpath
+  # If true, enables creation of the openebs-hostpath StorageClass
+  enabled: true
   # Available reclaim policies: Delete/Retain, defaults: Delete.
   reclaimPolicy: Delete
+  # If true, sets the openebs-hostpath StorageClass as the default StorageClass
   isDefaultClass: false
-  storageType: "hostpath"
   # Path on the host where local volumes of this storage class are mounted under.
   basePath: "/var/openebs/local"
   # Custom node affinity label for example "openebs.io/node-affinity-value" that will be

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -47,7 +47,13 @@ helm install openebs-localpv openebs-localpv/localpv-provisioner -n openebs --cr
 helm install openebs-localpv openebs-localpv/localpv-provisioner -n openebs --create-namespace \
 	--set openebsNDM.enabled=false
 ```
-  2. Install the OpenEBS Dynamic LocalPV Provisioner with a custom hostpath directory. 
+  2. Install OpenEBS Dynamic LocalPV Provisioner for Hostpath volumes only
+```console
+helm install openebs-localpv openebs-localpv/localpv-provisioner -n openebs --create-namespace \
+	--set openebsNDM.enabled=false
+	--set deviceClass.enabled=false
+```
+  3. Install OpenEBS Dynamic LocalPV Provisioner with a custom hostpath directory. 
      This will change the `BasePath` value for the 'openebs-hostpath' StorageClass.
 ```console
 helm install openebs-localpv openebs-localpv/localpv-provisioner -n openebs --create-namespace \
@@ -63,9 +69,21 @@ Install the OpenEBS Dynamic LocalPV Provisioner using the following command:
 kubectl apply -f https://openebs.github.io/charts/openebs-operator-lite.yaml -f https://openebs.github.io/charts/openebs-lite-sc.yaml
 ```
 
+You are ready to provision LocalPV volumes once the pods in 'openebs' namespace report RUNNING status.
+```console
+$ kubectl get pods -n openebs
+
+NAME                                           READY   STATUS    RESTARTS   AGE
+openebs-localpv-provisioner-5696c4f884-mvfvz   1/1     Running   0          7s
+openebs-ndm-ctn5d                              1/1     Running   0          8s
+openebs-ndm-lpf86                              1/1     Running   0          8s
+openebs-ndm-operator-6b86bbc48-7lf7r           0/1     Running   0          8s
+openebs-ndm-pqr2v                              1/1     Running   0          8s
+```
+
 ## Provisioning LocalPV Hostpath Persistent Volume
 
-You can provision LocalPV Hostpath volumes using the default `openebs-hostpath` StorageClass.
+You can provision LocalPV Hostpath volumes dynamically using the default `openebs-hostpath` StorageClass.
 
 <details>
   <summary>Click here if you want to configure your own custom StorageClass.</summary>
@@ -84,15 +102,10 @@ You can provision LocalPV Hostpath volumes using the default `openebs-hostpath` 
       cas.openebs.io/config: |
         - name: StorageType
           value: hostpath
-      
-      ## Use this to set a custom hostpath directory
-      # - name: BasePath
-      #   value: /mnt/data
-      
-      ## Use this to set a custom label for node selection
-      ## (e.g. when nodename tends to change)
-      # - name: NodeAffinityLabel
-      #   value: "openebs.io/custom-node-unique-id"
+      # - name: BasePath     # Use this to set a custom 
+      #   value: /mnt/data   # hostpath directory
+      # - name: NodeAffinityLabel                   # Use this to set a custom 
+      #   value: "openebs.io/custom-node-unique-id" # label for node selection
   provisioner: openebs.io/local
   reclaimPolicy: Delete
   ## It is necessary to have volumeBindingMode as WaitForFirstConsumer
@@ -137,7 +150,7 @@ openebs-ndm-vgdnv                       1/1     Running   0          6d6h
 openebs-ndm-operator-86b6dd687d-4lmpl   1/1     Running   0          6d7h
 ```
 
-You can provision LocalPV Hostpath volumes using the default `openebs-device` StorageClass.
+You can provision LocalPV Hostpath volumes dynamically using the default `openebs-device` StorageClass.
 
 <details>
   <summary>Click here if you want to configure your own custom StorageClass.</summary>
@@ -156,22 +169,10 @@ You can provision LocalPV Hostpath volumes using the default `openebs-device` St
       cas.openebs.io/config: |
         - name: StorageType
           value: device
-      
-      ## Use this to set the filesystem type. Default is ext4
-      # - name: FSType
-      #   value: xfs
-      
-      ## Use this to set a custom label for node selection
-      ## (e.g. when nodename tends to change)
-      # - name: NodeAffinityLabel
-      #   value: "openebs.io/custom-node-unique-id"
-
-      ## Only BlockDevices with the label openebs.io/block-device-tag=mongo
-      ## will be considered for provisioning
-      ## Requires you to label BlockDevices as below...
-      ## kubectl -n openebs label bd <name> openebs.io/block-device-tag=mongo
-      # - name: BlockDeviceTag
-      #   value: "mongo"
+      # - name: FSType  # Use this to set the filesystem
+      #   value: xfs    # type. Default is ext4.
+      # - name: BlockDeviceTag  # Only blockdevices with the label 
+      #   value: "mongo"        # openebs.io/block-device-tag=mongo will be used
   provisioner: openebs.io/local
   reclaimPolicy: Delete
   ## It is necessary to have volumeBindingMode as WaitForFirstConsumer
@@ -204,7 +205,7 @@ spec:
       ## Set capacity here
       storage: 5Gi
 ```
-The PVC will be in 'Pending' state until the volume is mounted.
+The PVC will be in 'Pending' state until the volume is mounted/attached.
 ```console
 $ kubectl get pvc
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -48,7 +48,7 @@ helm install openebs-localpv openebs-localpv/localpv-provisioner -n openebs --cr
 	--set openebsNDM.enabled=false
 ```
   2. Install the OpenEBS Dynamic LocalPV Provisioner with a custom hostpath directory. 
-     This will change the `BasePath` value for the 'openebs-hostpath' storageClass.
+     This will change the `BasePath` value for the 'openebs-hostpath' StorageClass.
 ```console
 helm install openebs-localpv openebs-localpv/localpv-provisioner -n openebs --create-namespace \
 	--set hostpathClass.basePath=<custom-hostpath>
@@ -60,6 +60,180 @@ helm install openebs-localpv openebs-localpv/localpv-provisioner -n openebs --cr
 ## Install using operator YAML
 Install the OpenEBS Dynamic LocalPV Provisioner using the following command:
 ```console
-kubectl apply -f https://openebs.github.io/charts/openebs-operator-lite.yaml \
-		-f https://openebs.github.io/charts/openebs-lite-sc.yaml
+kubectl apply -f https://openebs.github.io/charts/openebs-operator-lite.yaml -f https://openebs.github.io/charts/openebs-lite-sc.yaml
+```
+
+## Provisioning LocalPV Hostpath Persistent Volume
+
+You can provision LocalPV Hostpath volumes using the default `openebs-hostpath` StorageClass.
+
+<details>
+  <summary>Click here if you want to configure your own custom StorageClass.</summary>
+
+  ```yaml
+  # This is a custom StorageClass template
+  # Uncomment config options as desired
+  apiVersion: storage.k8s.io/v1
+  kind: StorageClass
+  metadata:
+    name: custom-hostpath
+    annotations:
+      ## Use this annotation to set this StorageClass by default
+      # storageclass.kubernetes.io/is-default-class: true
+      openebs.io/cas-type: local
+      cas.openebs.io/config: |
+        - name: StorageType
+          value: hostpath
+      
+      ## Use this to set a custom hostpath directory
+      # - name: BasePath
+      #   value: /mnt/data
+      
+      ## Use this to set a custom label for node selection
+      ## (e.g. when nodename tends to change)
+      # - name: NodeAffinityLabel
+      #   value: "openebs.io/custom-node-unique-id"
+  provisioner: openebs.io/local
+  reclaimPolicy: Delete
+  ## It is necessary to have volumeBindingMode as WaitForFirstConsumer
+  volumeBindingMode: WaitForFirstConsumer
+  ```
+</details>
+
+Create a PVC with the StorageClass.
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: localpv-vol
+spec:
+  ## Change this name if you are using a custom StorageClass
+  storageClassName: openebs-hostpath
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      ## Set capacity here
+      storage: 5Gi
+```
+The PVC will be in 'Pending' state until the volume is mounted.
+```console
+$ kubectl get pvc
+
+NAME          STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS       AGE
+localpv-vol   Pending                                      openebs-hostpath   21s
+```
+
+
+## Provisioning LocalPV Device Persistent Volume
+
+You must have NDM installed to be able to use LocalPV Device. Use the following command to check if NDM pods are present:
+```console
+$ kubectl -n openebs get pods  -l 'openebs.io/component-name in (ndm, ndm-operator)'
+
+NAME                                    READY   STATUS    RESTARTS   AGE
+openebs-ndm-gctb7                       1/1     Running   0          6d7h
+openebs-ndm-sfczv                       1/1     Running   0          6d7h
+openebs-ndm-vgdnv                       1/1     Running   0          6d6h
+openebs-ndm-operator-86b6dd687d-4lmpl   1/1     Running   0          6d7h
+```
+
+You can provision LocalPV Hostpath volumes using the default `openebs-device` StorageClass.
+
+<details>
+  <summary>Click here if you want to configure your own custom StorageClass.</summary>
+
+  ```yaml
+  # This is a custom StorageClass template
+  # Uncomment config options as desired
+  apiVersion: storage.k8s.io/v1
+  kind: StorageClass
+  metadata:
+    name: custom-device
+    annotations:
+      ## Use this annotation to set this StorageClass by default
+      # storageclass.kubernetes.io/is-default-class: true
+      openebs.io/cas-type: local
+      cas.openebs.io/config: |
+        - name: StorageType
+          value: device
+      
+      ## Use this to set the filesystem type. Default is ext4
+      # - name: FSType
+      #   value: xfs
+      
+      ## Use this to set a custom label for node selection
+      ## (e.g. when nodename tends to change)
+      # - name: NodeAffinityLabel
+      #   value: "openebs.io/custom-node-unique-id"
+
+      ## Only BlockDevices with the label openebs.io/block-device-tag=mongo
+      ## will be considered for provisioning
+      ## Requires you to label BlockDevices as below...
+      ## kubectl -n openebs label bd <name> openebs.io/block-device-tag=mongo
+      # - name: BlockDeviceTag
+      #   value: "mongo"
+  provisioner: openebs.io/local
+  reclaimPolicy: Delete
+  ## It is necessary to have volumeBindingMode as WaitForFirstConsumer
+  volumeBindingMode: WaitForFirstConsumer
+  ## Match labels in allowedTopologies to select nodes for volume provisioning
+  # allowedTopologies:
+  # - matchLabelExpressions:
+  #   - key: kubernetes.io/hostname
+  #     values:
+  #     - worker-1
+  #     - worker-2
+  ```
+</details>
+
+Create a PVC with the StorageClass.
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: localpv-vol
+spec:
+  ## Change this name if you are using a custom StorageClass
+  storageClassName: openebs-device
+  accessModes: ["ReadWriteOnce"]
+  ## You can also provision a raw block volume
+  # volumeMode: Block
+  volumeMode: Filesystem
+  resources:
+    requests:
+      ## Set capacity here
+      storage: 5Gi
+```
+The PVC will be in 'Pending' state until the volume is mounted.
+```console
+$ kubectl get pvc
+
+NAME          STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS     AGE
+localpv-vol   Pending                                      openebs-device   21s
+```
+**Note**: LocalPV Device requires an Active and Unclaimed BlockDevice to be present on the node for provisioning to succeed. You may use allowedTopologies in your StorageClass to specify which nodes are usable.
+
+## Mount the volume
+
+Mount the volume to the application pod container. The PVC status will change to 'Bound' when the volume is mounted to a container. A sample BusyBox Pod template is given below.
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+spec:
+  containers:
+  - command:
+       - sh
+       - -c
+       - 'date >> /mnt/openebs-csi/date.txt; hostname >> /mnt/openebs-csi/hostname.txt; sync; sleep 5; sync; tail -f /dev/null;'
+    image: busybox
+    name: busybox
+    volumeMounts:
+    - mountPath: /mnt/data
+      name: demo-vol
+  volumes:
+  - name: demo-vol
+    persistentVolumeClaim:
+      claimName: localpv-vol
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,11 +2,35 @@
 
 ## Prerequisites
 
-A Kubernetes cluster with Kubernetes v1.14 or above is required.
+A Kubernetes cluster with Kubernetes v1.14 or above is required. 
+
+<details>
+  <summary>Click here if you are using RKE or Rancher 2.x.</summary>
+
+  To use OpenEBS LocalPV Hostpath with an RKE/Rancher 2.x cluster, you will have to mount the hostpath directories to the kubelet containers. You can do this by editing the kubelet configuration section of your RKE/Rancher 2.x cluster and adding in the `extra_binds` (see below).
+
+  **Note:** If you want to use a custom hostpath directory, then you will have to mount the custom directory's absolute path. See below for an example with the default hostpath directory.
+
+  For an RKE cluster, you can add the `extra_binds` to your cluster.yml file and apply the changes using the `rke up` command.
+
+  For a Rancher 2.x cluster, you can edit your cluster's configuration options and add the `extra_binds` there.
+
+  ```yaml
+  services:
+    kubelet:
+      extra_binds:
+      # Default hostpath directory
+      - /var/openebs/local:/var/openebs/local
+  ```
+
+  For more information, please go through the official Rancher documentaion -- [RKE - Kubernetes Configuration Options](https://rancher.com/docs/rke/latest/en/config-options/services/services-extras/#extra-binds), [RKE - Installation](https://rancher.com/docs/rke/latest/en/installation/#deploying-kubernetes-with-rke).
+</details>
 
 ## Install using Helm chart
 Install OpenEBS Dynamic LocalPV Provisioner using the localpv-provisioner helm chart. Sample command:
 ```console
+# helm repo add openebs-localpv https://openebs.github.io/dynamic-localpv-provisioner
+# helm repo update
 helm install openebs-localpv openebs-localpv/localpv-provisioner -n openebs --create-namespace
 ```
 	
@@ -31,7 +55,7 @@ helm install openebs-localpv openebs-localpv/localpv-provisioner -n openebs --cr
 ```
 </details>
 
-[Click here](https://openebs.github.io/dynamic-localpv-provisioner/) for detailed instructions.
+[Click here](https://openebs.github.io/dynamic-localpv-provisioner/) for detailed instructions on using the Helm chart.
 
 ## Install using operator YAML
 Install the OpenEBS Dynamic LocalPV Provisioner using the following command:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -61,7 +61,7 @@ helm install openebs-localpv openebs-localpv/localpv-provisioner -n openebs --cr
 ```
 </details>
 
-[Click here](https://openebs.github.io/dynamic-localpv-provisioner/) for detailed instructions on using the Helm chart.
+[Click here](https://github.com/openebs/dynamic-localpv-provisioner/blob/master/deploy/helm/charts/README.md) for detailed instructions on using the Helm chart.
 
 ## Install using operator YAML
 Install the OpenEBS Dynamic LocalPV Provisioner using the following command:
@@ -77,7 +77,7 @@ NAME                                           READY   STATUS    RESTARTS   AGE
 openebs-localpv-provisioner-5696c4f884-mvfvz   1/1     Running   0          7s
 openebs-ndm-ctn5d                              1/1     Running   0          8s
 openebs-ndm-lpf86                              1/1     Running   0          8s
-openebs-ndm-operator-6b86bbc48-7lf7r           0/1     Running   0          8s
+openebs-ndm-operator-6b86bbc48-7lf7r           1/1     Running   0          8s
 openebs-ndm-pqr2v                              1/1     Running   0          8s
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -238,3 +238,8 @@ spec:
     persistentVolumeClaim:
       claimName: localpv-vol
 ```
+
+
+Visit the official [OpenEBS documentaion](https://docs.openebs.io) for more information.
+
+Connect with the OpenEBS maintainers at the [Kubernetes Slack workspace](https://kubernetes.slack.com/messages/openebs). Visit [openebs.io/community](https://openebs.io/community) for details.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,41 @@
+# Quickstart
+
+## Prerequisites
+
+A Kubernetes cluster with Kubernetes v1.14 or above is required.
+
+## Install using Helm chart
+Install OpenEBS Dynamic LocalPV Provisioner using the localpv-provisioner helm chart. Sample command:
+```console
+helm install openebs-localpv openebs-localpv/localpv-provisioner -n openebs --create-namespace
+```
+	
+<details>
+  <summary>Click here for configuration options.</summary>
+
+  1. Install OpenEBS Dynamic LocalPV Provisioner without NDM. 
+     
+     You may choose to exclude the NDM subchart from installation if...
+     - you want to only use OpenEBS LocalPV Hostpath
+     - you already have NDM installed. Check if NDM pods exist with the command `kubectl get pods -n openebs -l 'openebs.io/component-name in (ndm, ndm-operator)'`
+
+```console
+helm install openebs-localpv openebs-localpv/localpv-provisioner -n openebs --create-namespace \
+	--set openebsNDM.enabled=false
+```
+  2. Install the OpenEBS Dynamic LocalPV Provisioner with a custom hostpath directory. 
+     This will change the `BasePath` value for the 'openebs-hostpath' storageClass.
+```console
+helm install openebs-localpv openebs-localpv/localpv-provisioner -n openebs --create-namespace \
+	--set hostpathClass.basePath=<custom-hostpath>
+```
+</details>
+
+[Click here](https://openebs.github.io/dynamic-localpv-provisioner/) for detailed instructions.
+
+## Install using operator YAML
+Install the OpenEBS Dynamic LocalPV Provisioner using the following command:
+```console
+kubectl apply -f https://openebs.github.io/charts/openebs-operator-lite.yaml \
+		-f https://openebs.github.io/charts/openebs-lite-sc.yaml
+```


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

Resolves https://github.com/openebs/dynamic-localpv-provisioner/issues/42

1. Added docs/quickstart.md
2. Reworked helm chart README.md and NOTES.txt
3. Added `enabled: true` helm chart parameter for hostpath and device StorageClasses. Added new 'only hostpath' use case in quickstart.
4. #50 and https://github.com/openebs/dynamic-localpv-provisioner/pull/51  tackle docs changes in gh-pages branch