### PR TITLE
(bugsbash) remove repeat imports

### DIFF
--- a/pkg/kubernetes/api/core/v1/persistentvolume/kubernetes_test.go
+++ b/pkg/kubernetes/api/core/v1/persistentvolume/kubernetes_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	errors "github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -36,24 +35,24 @@ func fakeGetClientSetForPathErr(fakeConfigPath string) (cli *kubernetes.Clientse
 	return nil, errors.New("fake error")
 }
 
-func fakeGetOk(cli *kubernetes.Clientset, name string, opts metav1.GetOptions) (*corev1.PersistentVolume, error) {
-	return &corev1.PersistentVolume{}, nil
+func fakeGetOk(cli *kubernetes.Clientset, name string, opts metav1.GetOptions) (*v1.PersistentVolume, error) {
+	return &v1.PersistentVolume{}, nil
 }
 
-func fakeListOk(cli *kubernetes.Clientset, opts metav1.ListOptions) (*corev1.PersistentVolumeList, error) {
-	return &corev1.PersistentVolumeList{}, nil
+func fakeListOk(cli *kubernetes.Clientset, opts metav1.ListOptions) (*v1.PersistentVolumeList, error) {
+	return &v1.PersistentVolumeList{}, nil
 }
 
 func fakeDeleteOk(cli *kubernetes.Clientset, name string, opts *metav1.DeleteOptions) error {
 	return nil
 }
 
-func fakeListErr(cli *kubernetes.Clientset, opts metav1.ListOptions) (*corev1.PersistentVolumeList, error) {
-	return &corev1.PersistentVolumeList{}, errors.New("some error")
+func fakeListErr(cli *kubernetes.Clientset, opts metav1.ListOptions) (*v1.PersistentVolumeList, error) {
+	return &v1.PersistentVolumeList{}, errors.New("some error")
 }
 
-func fakeGetErr(cli *kubernetes.Clientset, name string, opts metav1.GetOptions) (*corev1.PersistentVolume, error) {
-	return &corev1.PersistentVolume{}, errors.New("some error")
+func fakeGetErr(cli *kubernetes.Clientset, name string, opts metav1.GetOptions) (*v1.PersistentVolume, error) {
+	return &v1.PersistentVolume{}, errors.New("some error")
 }
 
 func fakeDeleteErr(cli *kubernetes.Clientset, name string, opts *metav1.DeleteOptions) error {
@@ -82,11 +81,11 @@ func fakeGetClientSetErr() (clientset *kubernetes.Clientset, err error) {
 
 func fakeClientSet(k *Kubeclient) {}
 
-func fakeCreateFnOk(cli *kubernetes.Clientset, pv *corev1.PersistentVolume) (*corev1.PersistentVolume, error) {
-	return &corev1.PersistentVolume{}, nil
+func fakeCreateFnOk(cli *kubernetes.Clientset, pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
+	return &v1.PersistentVolume{}, nil
 }
 
-func fakeCreateFnErr(cli *kubernetes.Clientset, pv *corev1.PersistentVolume) (*corev1.PersistentVolume, error) {
+func fakeCreateFnErr(cli *kubernetes.Clientset, pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
 	return nil, errors.New("failed to create PV")
 }
 

--- a/pkg/kubernetes/api/core/v1/persistentvolumeclaim/kubernetes_test.go
+++ b/pkg/kubernetes/api/core/v1/persistentvolumeclaim/kubernetes_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	errors "github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -36,24 +35,24 @@ func fakeGetClientSetForPathErr(fakeConfigPath string) (cli *kubernetes.Clientse
 	return nil, errors.New("fake error")
 }
 
-func fakeGetOk(cli *kubernetes.Clientset, name, namespace string, opts metav1.GetOptions) (*corev1.PersistentVolumeClaim, error) {
-	return &corev1.PersistentVolumeClaim{}, nil
+func fakeGetOk(cli *kubernetes.Clientset, name, namespace string, opts metav1.GetOptions) (*v1.PersistentVolumeClaim, error) {
+	return &v1.PersistentVolumeClaim{}, nil
 }
 
-func fakeListOk(cli *kubernetes.Clientset, namespace string, opts metav1.ListOptions) (*corev1.PersistentVolumeClaimList, error) {
-	return &corev1.PersistentVolumeClaimList{}, nil
+func fakeListOk(cli *kubernetes.Clientset, namespace string, opts metav1.ListOptions) (*v1.PersistentVolumeClaimList, error) {
+	return &v1.PersistentVolumeClaimList{}, nil
 }
 
 func fakeDeleteOk(cli *kubernetes.Clientset, name, namespace string, opts *metav1.DeleteOptions) error {
 	return nil
 }
 
-func fakeListErr(cli *kubernetes.Clientset, namespace string, opts metav1.ListOptions) (*corev1.PersistentVolumeClaimList, error) {
-	return &corev1.PersistentVolumeClaimList{}, errors.New("some error")
+func fakeListErr(cli *kubernetes.Clientset, namespace string, opts metav1.ListOptions) (*v1.PersistentVolumeClaimList, error) {
+	return &v1.PersistentVolumeClaimList{}, errors.New("some error")
 }
 
-func fakeGetErr(cli *kubernetes.Clientset, name, namespace string, opts metav1.GetOptions) (*corev1.PersistentVolumeClaim, error) {
-	return &corev1.PersistentVolumeClaim{}, errors.New("some error")
+func fakeGetErr(cli *kubernetes.Clientset, name, namespace string, opts metav1.GetOptions) (*v1.PersistentVolumeClaim, error) {
+	return &v1.PersistentVolumeClaim{}, errors.New("some error")
 }
 
 func fakeDeleteErr(cli *kubernetes.Clientset, name, namespace string, opts *metav1.DeleteOptions) error {
@@ -82,11 +81,11 @@ func fakeGetClientSetErr() (clientset *kubernetes.Clientset, err error) {
 
 func fakeClientSet(k *Kubeclient) {}
 
-func fakeCreateFnOk(cli *kubernetes.Clientset, namespace string, pvc *corev1.PersistentVolumeClaim) (*corev1.PersistentVolumeClaim, error) {
-	return &corev1.PersistentVolumeClaim{}, nil
+func fakeCreateFnOk(cli *kubernetes.Clientset, namespace string, pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {
+	return &v1.PersistentVolumeClaim{}, nil
 }
 
-func fakeCreateFnErr(cli *kubernetes.Clientset, namespace string, pvc *corev1.PersistentVolumeClaim) (*corev1.PersistentVolumeClaim, error) {
+func fakeCreateFnErr(cli *kubernetes.Clientset, namespace string, pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {
 	return nil, errors.New("failed to create PVC")
 }
 

--- a/pkg/kubernetes/api/core/v1/pod/kubernetes_test.go
+++ b/pkg/kubernetes/api/core/v1/pod/kubernetes_test.go
@@ -20,7 +20,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	client "k8s.io/client-go/kubernetes"
 	clientset "k8s.io/client-go/kubernetes"
 )
 
@@ -53,7 +52,7 @@ func fakeGetErrfn(cli *clientset.Clientset, namespace, name string, opts metav1.
 }
 
 func fakeSetClientset(k *KubeClient) {
-	k.clientset = &client.Clientset{}
+	k.clientset = &clientset.Clientset{}
 }
 
 func fakeSetNilClientset(k *KubeClient) {
@@ -193,11 +192,11 @@ func TestGetClientSetForPathOrDirect(t *testing.T) {
 
 func TestWithClientsetBuildOption(t *testing.T) {
 	tests := map[string]struct {
-		Clientset             *client.Clientset
+		Clientset             *clientset.Clientset
 		expectKubeClientEmpty bool
 	}{
 		"Clientset is empty":     {nil, true},
-		"Clientset is not empty": {&client.Clientset{}, false},
+		"Clientset is not empty": {&clientset.Clientset{}, false},
 	}
 
 	for name, mock := range tests {


### PR DESCRIPTION
Signed-off-by: aSquare14 <atibhi.a@gmail.com>

## Pull Request template

**Why is this PR required? What issue does it fix?**:
Fixes package "k8s.io/api/core/v1" is being imported more than once and improves consistency.
**What this PR does?**:

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 


**PLEASE REMOVE BELOW INFORMATION BEFORE SUBMITTING**

The PR title message must follow convention:
   `<type>(<scope>): <subject>`.

Where:
    Most common types are:
    * `feat`        - for new features, not a new feature for build script
    * `fix`         - for bug fixes or improvements, not a fix for build script
    * `chore`       - changes not related to production code
    * `docs`        - changes related to documentation
    * `style`       - formatting, missing semi colons, linting fix etc; no significant production code changes
    * `test`        - adding missing tests, refactoring tests; no production code change
    * `refactor`    - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes
    * `cherry-pick` - if PR is merged in master branch and raised to release branch(like v0.4.x)
    
IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
