### PR TITLE
refact(env): Change default registry for linux-utils image to default registry (docker.io)

### DIFF
--- a/cmd/provisioner-localpv/app/env.go
+++ b/cmd/provisioner-localpv/app/env.go
@@ -45,7 +45,7 @@ const (
 )
 
 var (
-	defaultHelperImage = "quay.io/openebs/linux-utils:latest"
+	defaultHelperImage = "openebs/linux-utils:latest"
 	defaultBasePath    = "/var/openebs/local"
 )
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-A Kubernetes cluster with Kubernetes v1.19 or above is required. 
+A Kubernetes cluster with Kubernetes v1.16 or above is required. 
 
 <details>
   <summary>Click here if you are using RKE or Rancher 2.x.</summary>


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

**Why is this PR required? What issue does it fix?**:
Uses docker as the default registry for the linux-utils image used in localpv helper pods. This is to keep with the convention of using docker registry by default.

Change k8s version prerequisite to 1.16 based on the availability of CustomResourceDefinition on apiextension.k8s.io/v1 (BlockDevice and BlockDeviceClaim CRs from github.com/openebs/node-disk-manager repo).
Ref: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122

**What this PR does?**:
Changes the string value of the default linux-utils image variable.
Docs change.

**Does this PR require any upgrade changes?**:
No.