### PR TITLE
feat(provisioner): add data source validation

### DIFF
--- a/cmd/provisioner-localpv/app/types.go
+++ b/cmd/provisioner-localpv/app/types.go
@@ -18,9 +18,16 @@ limitations under the License.
 package app
 
 import (
-	mconfig "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
+
+	mconfig "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+)
+
+const (
+	SnapshotKind     string = "VolumeSnapshot"
+	PVCKind          string = "PersistentVolumeClaim"
+	SnapshotAPIGroup string = "snapshot.storage.k8s.io"
 )
 
 //Provisioner struct has the configuration and utilities required


### PR DESCRIPTION
PVC DataSource can refer to PVC or Snapshot or custom Populator. Clone and Snapshot functionalities are internal to the provisioner. Custom Populator works as plugin model provisioner should not create a volume if DataSource is a custom Populator.
As Clone and Snapshot feature is not supported by this provisioner for any DataSource the provisioner should not create the volume.
