### PR TITLE
chore(operator-yaml): add bd timeout flag and env to deploy/kubectl/hostpath-operator.yaml

### DIFF
--- a/buildscripts/provisioner-localpv/Dockerfile
+++ b/buildscripts/provisioner-localpv/Dockerfile
@@ -37,4 +37,4 @@ LABEL org.label-schema.build-date=$DBUILD_DATE
 LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
 LABEL org.label-schema.url=$DBUILD_SITE_URL
 
-CMD ["/provisioner-localpv"]
+ENTRYPOINT ["/provisioner-localpv"]

--- a/deploy/kubectl/hostpath-operator.yaml
+++ b/deploy/kubectl/hostpath-operator.yaml
@@ -75,7 +75,7 @@ spec:
         imagePullPolicy: IfNotPresent
         image: openebs/provisioner-localpv:ci
         args:
-          - "-bd-time-out=${BDC_BD_BIND_TIMEOUT}"
+          - "--bd-time-out=$(BDC_BD_BIND_TIMEOUT)"
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
         # based on this address. This is ignored if empty.

--- a/deploy/kubectl/hostpath-operator.yaml
+++ b/deploy/kubectl/hostpath-operator.yaml
@@ -74,6 +74,8 @@ spec:
       - name: openebs-provisioner-hostpath
         imagePullPolicy: IfNotPresent
         image: openebs/provisioner-localpv:ci
+        args:
+          - "-bd-time-out=${BDC_BD_BIND_TIMEOUT}"
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
         # based on this address. This is ignored if empty.
@@ -85,6 +87,11 @@ spec:
         # This is supported for openebs provisioner version 0.5.2 onwards
         #- name: OPENEBS_IO_KUBE_CONFIG
         #  value: "/home/ubuntu/.kube/config"
+        #  This sets the number of seconds the provisioner should wait for
+        #  a BlockDevice to get bound to a BlockDeviceClaim, before the
+        #  BlockDeviceClaim is deleted.
+        - name: BDC_BD_BIND_TIMEOUT
+          value: "60"
         - name: NODE_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

Changes:
- This makes changes to the env section and the args section in the Deployment Pod spec to set the default BD timeout to be 60s.
- buildscripts/provisioner-localpv/Dockerfile had a CMD statement. This does not work with the args section in the Kubernetes YAML spec. Changed this to an ENTRYPOINT statement. The 'make provisioner-localpv-image' builds an image using this dockerfile.