### PR TITLE
cherry-pick #85

### DIFF
--- a/cmd/provisioner-localpv/app/provisioner.go
+++ b/cmd/provisioner-localpv/app/provisioner.go
@@ -80,7 +80,7 @@ func NewProvisioner(kubeClient *clientset.Clientset) (*Provisioner, error) {
 
 // SupportsBlock will be used by controller to determine if block mode is
 //  supported by the host path provisioner.
-func (p *Provisioner) SupportsBlock() bool {
+func (p *Provisioner) SupportsBlock(ctx context.Context) bool {
 	return true
 }
 


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

**Why is this PR required? What issue does it fix?**:
There has been a regression due to #74. SupportsBlock() requires an argument now, a context.Context. This change was not addressed in #74, and this has removed Block volumeMode support.

**What this PR does?**:
Adds an argument to the method SupportsBlock() for a context.Context.

**Does this PR require any upgrade changes?**:
No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Integration tests for Block volume pass when this change is made.

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_
This is a cherry-pick of https://github.com/openebs/dynamic-localpv-provisioner/pull/85