### PR TITLE
chore(helm-chart): update localpv-provisioner helm chart to v2.12.0

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,10 +4,10 @@ description: Helm chart for OpenEBS Dynamic Local PV. For instructions to instal
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.11.1
+version: 2.12.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.11.1
+appVersion: 2.12.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/
 keywords:
@@ -19,7 +19,7 @@ sources:
 
 dependencies:
   - name: openebs-ndm
-    version: "1.6.0"
+    version: "1.6.1"
     repository: "https://openebs.github.io/node-disk-manager"
     condition: openebsNDM.enabled
 

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -46,7 +46,7 @@ By default this chart installs additional, dependent charts:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://openebs.github.io/node-disk-manager | openebs-ndm | 1.6.0 |
+| https://openebs.github.io/node-disk-manager | openebs-ndm | 1.6.1 |
 
 **Note:** Find detailed Node Disk Manager Helm chart configuration options [here](https://github.com/openebs/node-disk-manager/blob/master/deploy/helm/charts/README.md).
 
@@ -92,7 +92,7 @@ helm install openebs-localpv openebs-localpv/localpv-provisioner --namespace ope
 
 | Parameter                                   | Description                                   | Default                                   |
 | ------------------------------------------- | --------------------------------------------- | ----------------------------------------- |
-| `release.version`                           | LocalPV Provisioner release version               | `2.11.1`                        |
+| `release.version`                           | LocalPV Provisioner release version               | `2.12.0`                        |
 | `analytics.enabled`                         | Enable sending stats to Google Analytics          | `true`                          |
 | `analytics.pingInterval`                    | Duration(hours) between sending ping stat         | `24h`                           |
 | `deviceClass.blockDeviceTag`                | Value of `openebs.io/block-device-tag` BD label   | `""`                            |
@@ -103,7 +103,7 @@ helm install openebs-localpv openebs-localpv/localpv-provisioner --namespace ope
 | `helperPod.image.registry`                  | Registry for helper image                         | `""`                            |
 | `helperPod.image.repository`                | Image for helper pod                              | `"openebs/linux-utils"`         |
 | `helperPod.image.pullPolicy`                | Pull policy for helper pod                        | `"IfNotPresent"`                |
-| `helperPod.image.tag`                       | Image tag for helper image                        | `2.11.0`                        |
+| `helperPod.image.tag`                       | Image tag for helper image                        | `2.12.0`                        |
 | `hostpathClass.basePath`                    | BasePath for openebs-hostpath StorageClass        | `"/var/openebs/local"`          |
 | `hostpathClass.enabled`                     | Enables creation of default Hostpath StorageClass | `true`                          |
 | `hostpathClass.isDefaultClass`              | Make openebs-hostpath the default StorageClass    | `"false"`                       |
@@ -114,7 +114,7 @@ helm install openebs-localpv openebs-localpv/localpv-provisioner --namespace ope
 | `localpv.image.registry`                    | Registry for LocalPV Provisioner image            | `""`                            |
 | `localpv.image.repository`                  | Image repository for LocalPV Provisioner          | `openebs/localpv-provisioner`   |
 | `localpv.image.pullPolicy`                  | Image pull policy for LocalPV Provisioner         | `IfNotPresent`                  |
-| `localpv.image.tag`                         | Image tag for LocalPV Provisioner                 | `2.11.1`                        |
+| `localpv.image.tag`                         | Image tag for LocalPV Provisioner                 | `2.12.0`                        |
 | `localpv.updateStrategy.type`               | Update strategy for LocalPV Provisioner           | `RollingUpdate`                 |
 | `localpv.annotations`                       | Annotations for LocalPV Provisioner metadata      | `""`                            |
 | `localpv.podAnnotations`                    | Annotations for LocalPV Provisioner pods metadata | `""`                            |
@@ -129,6 +129,7 @@ helm install openebs-localpv openebs-localpv/localpv-provisioner --namespace ope
 | `localpv.replicas`                          | No. of LocalPV Provisioner replica                | `1`                             |
 | `localpv.enableLeaderElection`              | Enable leader election                            | `true`                          |
 | `localpv.affinity`                          | LocalPV Provisioner pod affinity                  | `{}`                            |
+| `localpv.waitForBDBindTimeoutRetryCount`    | This sets the number of times the provisioner should try with a polling interval of 5 seconds, to get the Blockdevice Name from a BlockDeviceClaim, before the BlockDeviceClaim is deleted. | "12" |
 | `openebsNDM.enabled`                        | Install openebs NDM dependency                    | `true`                          |
 | `rbac.create`                               | Enable RBAC Resources                             | `true`                          |
 | `rbac.pspEnabled`                           | Create pod security policy resources              | `false`                         |

--- a/deploy/helm/charts/templates/deployment.yaml
+++ b/deploy/helm/charts/templates/deployment.yaml
@@ -40,6 +40,8 @@ spec:
         imagePullPolicy: {{ .Values.localpv.image.pullPolicy }}
         resources:
 {{ toYaml .Values.localpv.resources | indent 10 }}
+        args:
+          - "--bd-time-out=$(BDC_BD_BIND_RETRIES)"
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
         # based on this address. This is ignored if empty.
@@ -51,8 +53,12 @@ spec:
         # This is supported for openebs provisioner version 0.5.2 onwards
         #- name: OPENEBS_IO_KUBE_CONFIG
         #  value: "/home/ubuntu/.kube/config"
-        # OPENEBS_NAMESPACE is the namespace that this provisioner will
-        # lookup to find maya api service
+        #  This sets the number of times the provisioner should try
+        #  with a polling interval of 5 seconds, to get the Blockdevice
+        #  Name from a BlockDeviceClaim, before the BlockDeviceClaim
+        #  is deleted. E.g. 12 * 5 seconds = 60 seconds timeout
+        - name: BDC_BD_BIND_RETRIES
+          value: "{{ .Values.localpv.waitForBDBindTimeoutRetryCount }}"
         - name: OPENEBS_NAMESPACE
           valueFrom:
             fieldRef:

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -40,7 +40,7 @@ localpv:
   replicas: 1
   enableLeaderElection: true
   basePath: "/var/openebs/local"
-# This sets the number of times the provisioner should try 
+# This sets the number of times the provisioner should try
 # with a polling interval of 5 seconds, to get the Blockdevice
 # Name from a BlockDeviceClaim, before the BlockDeviceClaim
 # is deleted. E.g. 12 * 5 seconds = 60 seconds timeout

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 release:
-  version: "2.11.1"
+  version: "2.12.0"
 
 rbac:
   # rbac.create: `true` if rbac resources should be created
@@ -23,7 +23,7 @@ localpv:
     # For example : quay.io/ is a correct value here and quay.io is incorrect
     registry:
     repository: openebs/provisioner-localpv
-    tag: 2.11.1
+    tag: 2.12.0
     pullPolicy: IfNotPresent
   updateStrategy:
     type: RollingUpdate
@@ -40,6 +40,11 @@ localpv:
   replicas: 1
   enableLeaderElection: true
   basePath: "/var/openebs/local"
+# This sets the number of times the provisioner should try 
+# with a polling interval of 5 seconds, to get the Blockdevice
+# Name from a BlockDeviceClaim, before the BlockDeviceClaim
+# is deleted. E.g. 12 * 5 seconds = 60 seconds timeout
+  waitForBDBindTimeoutRetryCount: "12"
   resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -57,7 +62,7 @@ localpv:
   securityContext: {}
 
 imagePullSecrets:
-#  - name: img-pull-secret
+  # - name: img-pull-secret
 
 podSecurityContext: {}
   # fsGroup: 2000
@@ -113,7 +118,7 @@ helperPod:
     repository: openebs/linux-utils
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 2.11.0
+    tag: 2.12.0
 
 analytics:
   enabled: true


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

Changes:
1. Add --be-time-out flag to openebs-localpv-provisioner deployment template
2. Add `localpv.waitForBDBindTimeoutRetryCount` parameter to set the --bd-time-out flag env.
3. Bump chart version to 2.12.0