### PR TITLE
chore(README): add badges, adopters link, roadmap link, compatibility matrix, project status to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![GitHub go.mod Go version (develop)](https://img.shields.io/github/go-mod/go-version/openebs/dynamic-localpv-provisioner/develop?style=flat)](https://github.com/openebs/dynamic-localpv-provisioner/blob/develop/go.mod)
 [![codecov](https://codecov.io/gh/openebs/dynamic-localpv-provisioner/branch/develop/graph/badge.svg)](https://codecov.io/gh/openebs/dynamic-localpv-provisioner)
 [![Go Report Card](https://goreportcard.com/badge/github.com/openebs/maya)](https://goreportcard.com/report/github.com/openebs/maya)
+![stability-beta](https://img.shields.io/badge/stability-beta-33bbff.svg)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/openebs/dynamic-localpv-provisioner/blob/develop/LICENSE)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fopenebs%2Fdynamic-localpv-provisioner.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fopenebs%2Fdynamic-localpv-provisioner?ref=badge_shield)
 
@@ -16,6 +17,8 @@ Kubernetes Local Volumes using different kinds of storage available on the Kuber
 <br>
 <br>
 </p>
+
+## Project Status: Beta
 
 Local Persistent Volumes are great for distributed cloud native data services that can handle resiliency and availability and expect low-latency access to the storage. Local Persistent Volumes can be provisioned using the hostpath, NVMe or PCIe based SSDs, Hard Disks or on top of other filesystems like ZFS, LVM. 
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ differences include:
   attached to the node and hostpath based Local PVs offer efficient management
   of the storage available on the node.
 
+## Kubernetes Compatibity Matrix
+
+|                               | Kubernetes <= 1.15 | Kubernetes 1.16 | Kubernetes 1.17 | Kubernetes 1.18 | Kubernetes 1.19 | Kubernetes 1.20 | Kubernetes 1.21 | Kubernetes 1.22 |
+|-------------------------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|
+| `localpv-provisioner-2.10.1`/`v2.10.1` | ✕              | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               |
+| `localpv-provisioner-2.11.1`/`v2.11.1` | ✕              | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               |
+| `localpv-provisioner-2.12.0`/`v2.12.0` | ✕              | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               |
+| `HEAD`                                 | ✕              | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               |
+
+
 ## Install
 
 Please refer to our [Quickstart](https://github.com/openebs/dynamic-localpv-provisioner/blob/develop/docs/quickstart.md) and the [OpenEBS Documentation](http://docs.openebs.io/).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 # Dynamic Kubernetes Local Persistent Volumes
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/openebs/dynamic-localpv-provisioner?color=orange&style=for-the-badge)](https://github.com/openebs/dynamic-localpv-provisioner/blob/develop/docs/quickstart.md)<br>
+[![GitHub build (develop)](https://github.com/openebs/dynamic-localpv-provisioner/actions/workflows/build.yml/badge.svg?branch=develop)](https://github.com/openebs/dynamic-localpv-provisioner/actions/workflows/build.yml)
+[![GitHub go.mod Go version (develop)](https://img.shields.io/github/go-mod/go-version/openebs/dynamic-localpv-provisioner/develop?style=flat)](https://github.com/openebs/dynamic-localpv-provisioner/blob/develop/go.mod)
+[![codecov](https://codecov.io/gh/openebs/dynamic-localpv-provisioner/branch/develop/graph/badge.svg)](https://codecov.io/gh/openebs/dynamic-localpv-provisioner)
+[![Go Report Card](https://goreportcard.com/badge/github.com/openebs/maya)](https://goreportcard.com/report/github.com/openebs/maya)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/openebs/dynamic-localpv-provisioner/blob/develop/LICENSE)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fopenebs%2Fdynamic-localpv-provisioner.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fopenebs%2Fdynamic-localpv-provisioner?ref=badge_shield)
 
 
@@ -49,6 +55,10 @@ Please refer to our [Quickstart](https://github.com/openebs/dynamic-localpv-prov
 ## Contributing
 
 Head over to the [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## OpenEBS Adopters
+
+Check out the list of organizations and users who have chosen OpenEBS to run their stateful workloads, over at the [OpenEBS Adopters page](https://github.com/openebs/openebs/blob/master/ADOPTERS.md).
 
 ## Community, discussion, and support
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Please refer to our [Quickstart](https://github.com/openebs/dynamic-localpv-prov
 
 Head over to the [CONTRIBUTING.md](./CONTRIBUTING.md).
 
+## Roadmap
+
+Find the Dynamic Local PV roadmap items at the [OpenEBS Roadmap page](https://github.com/openebs/openebs/blob/master/ROADMAP.md#dynamic-local-pvs).
+
 ## OpenEBS Adopters
 
 Check out the list of organizations and users who have chosen OpenEBS to run their stateful workloads, over at the [OpenEBS Adopters page](https://github.com/openebs/openebs/blob/master/ADOPTERS.md).

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
 <strong>OpenEBS Dynamic Local PV provisioner</strong> can be used to dynamically provision 
 Kubernetes Local Volumes using different kinds of storage available on the Kubernetes nodes. 
 <br>
-<br>
 </p>
 
 ## Project Status: Beta


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>
Ref: #45 
This PR adds:
- badges (GitHub release version, Go version used in go.mod, Go reportcard, stability status, codecov, license version)
- the link to the adopters page in openebs/openebs to the main README.md
- the link to the roadmap page in openebs/openebs to the main README.md
- compatibility matrix for Kubernetes versions and releases v2.10.1, v2.11.1, v2.12.0 and branch HEAD.
