### PR TITLE
chore(integration-test): fix flakiness

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,13 +182,13 @@ jobs:
       - name: Set up Minikube
         uses: manusa/actions-setup-minikube@v2.4.2
         with:
-          minikube version: 'v1.22.0'
-          kubernetes version: 'v1.22.0'
+          minikube version: 'v1.23.0'
+          kubernetes version: 'v1.22.1'
           driver: none
 
       - name: Set up infra for integration test
         run: |
-          sudo apt-get update && sudo apt-get install -y xfsprogs
+          go install github.com/onsi/ginkgo/ginkgo@v1.16.4
           sudo fallocate -l 2.5GiB /mnt/disk.img
           sed -e "/path-filter/{N;N;N;s|\"\"|\"$(sudo losetup -fP /mnt/disk.img --show)\"|}" -e '/path-filter/{N;N;N;N;s|/dev/loop,||}' -e '/openebs-provisioner-hostpath/{N;s/IfNotPresent/Never/}' deploy/kubectl/openebs-operator-lite.yaml | kubectl apply -f -
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -125,13 +125,13 @@ jobs:
       - name: Set up Minikube
         uses: manusa/actions-setup-minikube@v2.4.2
         with:
-          minikube version: 'v1.22.0'
-          kubernetes version: 'v1.22.0'
+          minikube version: 'v1.23.0'
+          kubernetes version: 'v1.22.1'
           driver: none
 
       - name: Set up infra for integration test
         run: |
-          sudo apt-get update && sudo apt-get install -y xfsprogs
+          go install github.com/onsi/ginkgo/ginkgo@v1.16.4
           sudo fallocate -l 2.5GiB /mnt/disk.img
           sed -e "/path-filter/{N;N;N;s|\"\"|\"$(sudo losetup -fP /mnt/disk.img --show)\"|}" -e '/path-filter/{N;N;N;N;s|/dev/loop,||}' -e '/openebs-provisioner-hostpath/{N;s/IfNotPresent/Never/}' deploy/kubectl/openebs-operator-lite.yaml | kubectl apply -f -
 

--- a/Makefile
+++ b/Makefile
@@ -139,20 +139,20 @@ testv: format
 	@echo "--> Running go test verbose" ;
 	@go test -v $(PACKAGES)
 
-# Requires KUBECONFIG env
+# Requires KUBECONFIG env and Ginkgo binary
 .PHONY: integration-test
 integration-test:
-	@cd tests && go test -ginkgo.v
+	@cd tests && ginkgo -v
 
-# Requires KUBECONFIG env
+# Requires KUBECONFIG env and Ginkgo binary
 .PHONY: device-integration-test
 device-integration-test:
-	@cd tests && go test -ginkgo.v -ginkgo.skip="TEST HOSTPATH.*"
+	@cd tests && ginkgo -v -skip="TEST HOSTPATH.*"
 
-# Requires KUBECONFIG env
+# Requires KUBECONFIG env and Ginkgo binary
 .PHONY: hostpath-integration-test
 hostpath-integration-test:
-	@cd tests && go test -ginkgo.v -ginkgo.focus="TEST HOSTPATH.*"
+	@cd tests && ginkgo -v -focus="TEST HOSTPATH.*"
 
 .PHONY: format
 format:

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,7 +9,7 @@ Local PV Provisioner BDD tests are developed using ginkgo & gomega libraries.
 - These tests are meant to be run in a single-node Kubernetes
   cluster with one single available blockdevice (not mounted).
 
-- Some of the test features exclusive to the XFS filesystem.
+- Some of the tests test features exclusive to the XFS filesystem.
   To run the XFS tests, you will require the 'xfsprogs' package
   installed on your node.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,6 +9,16 @@ Local PV Provisioner BDD tests are developed using ginkgo & gomega libraries.
 - These tests are meant to be run in a single-node Kubernetes
   cluster with one single available blockdevice (not mounted).
 
+- Some of the test features exclusive to the XFS filesystem.
+  To run the XFS tests, you will require the 'xfsprogs' package
+  installed on your node.
+
+- You will require the Ginkgo binary to be able to run the tests.
+  Install the latest Ginkgo binary using the following command:
+  ```bash
+  $ go install github.com/onsi/ginkgo/ginkgo@latest
+  ```
+
 - Get your Kubernetes Cluster ready and make sure you can run 
   kubectl from your development machine. 
   Note down the path to the `kubeconfig` file used by kubectl 
@@ -20,12 +30,6 @@ Local PV Provisioner BDD tests are developed using ginkgo & gomega libraries.
 
   If you do not set this ENV, you will have to pass the file 
   to the Ginkgo CLI (see below)
-
-- You will require the Ginkgo binary to be able to run the tests.
-  Install the latest Ginkgo binary using the following command:
-  ```bash
-  $ go install github.com/onsi/ginkgo/ginkgo@latest
-  ```
 
 - The tests should not be run in parallel as it may lead to
   unavailability of blockdevices for some of the tests.

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,7 +7,7 @@ Local PV Provisioner BDD tests are developed using ginkgo & gomega libraries.
 ### Pre-requisites
 
 - These tests are meant to be run in a single-node Kubernetes
-  cluster with one single available blockdevice.
+  cluster with one single available blockdevice (not mounted).
 
 - Get your Kubernetes Cluster ready and make sure you can run 
   kubectl from your development machine. 
@@ -21,14 +21,14 @@ Local PV Provisioner BDD tests are developed using ginkgo & gomega libraries.
   If you do not set this ENV, you will have to pass the file 
   to the Ginkgo CLI (see below)
 
-- You will require the Ginkgo binary to be able to run the test.
+- You will require the Ginkgo binary to be able to run the tests.
   Install the latest Ginkgo binary using the following command:
   ```bash
   $ go install github.com/onsi/ginkgo/ginkgo@latest
   ```
 
-- Some of the tests require block devices (that are not mounted)
-  to be available in the cluster.
+- The tests should not be run in parallel as it may lead to
+  unavailability of blockdevices for some of the tests.
 
 - Install required OpenEBS LocalPV Provisioner components
   Example: `kubectl apply -f https://openebs.github.io/charts/openebs-operator-lite.yaml`

--- a/tests/README.md
+++ b/tests/README.md
@@ -12,14 +12,20 @@ Local PV Provisioner BDD tests are developed using ginkgo & gomega libraries.
 - Get your Kubernetes Cluster ready and make sure you can run 
   kubectl from your development machine. 
   Note down the path to the `kubeconfig` file used by kubectl 
-  to access your cluster.  Example: /home/<user>/.kube/config
+  to access your cluster.  Example: /home/\<user\>/.kube/config
 
-- (Optional) Set the KUBECONFIG environment variable on your 
+- Set the KUBECONFIG environment variable on your 
   development machine to point to the kubeconfig file. 
-  Example: `export KUBECONFIG=/home/<user>/.kube/config`
+  Example: `export KUBECONFIG=$HOME/.kube/config`
 
   If you do not set this ENV, you will have to pass the file 
-  to the go test (or ginkgo) CLI
+  to the Ginkgo CLI (see below)
+
+- You will require the Ginkgo binary to be able to run the test.
+  Install the latest Ginkgo binary using the following command:
+  ```bash
+  $ go install github.com/onsi/ginkgo/ginkgo@latest
+  ```
 
 - Some of the tests require block devices (that are not mounted)
   to be available in the cluster.
@@ -29,24 +35,17 @@ Local PV Provisioner BDD tests are developed using ginkgo & gomega libraries.
 
 ### Run tests
 
-- Run the tests by being in the localpv tests folder. 
+Run the tests by being in the localpv tests folder. 
   ```bash
   $ cd <repo-directory>/tests
-  $ go test -ginkgo.v
-  $ #Alternatively, you can run the test suite using the 'ginkgo' binary
-  $ #ginkgo -v
+  $ ginkgo -v
  ```
   In case the KUBECONFIG env is not configured, you can run:
  ```bash
-  $ go test -ginkgo.v -kubeconfig=/path/to/kubeconfig
-  $ #Alternatively, you can run the test suite using the 'ginkgo' binary
-  $ #ginkgo -v -- -kubeconfig=/path/to/kubeconfig
+  $ ginkgo -v -- -kubeconfig=/path/to/kubeconfig
  ```
 
   If your OpenEBS LocalPV components are in a different Kubernetes namespace than 'openebs', you may use the '-openebs-namespace' flag:
  ```bash
-  $ go test -ginkgo.v -openebs-namespace=<your-namespace>
-  $ #Alternatively, you can run the test suite using the 'ginkgo' binary
-  $ #ginkgo -v -- -openebs-namespace=<your-namespace>
+  $ ginkgo -v -- -openebs-namespace=<your-namespace>
  ```
-

--- a/tests/README.md
+++ b/tests/README.md
@@ -53,3 +53,5 @@ Run the tests by being in the localpv tests folder.
  ```bash
   $ ginkgo -v -- -openebs-namespace=<your-namespace>
  ```
+
+ > **Tip:** Raising a pull request to this repo's 'develop' branch (or any one of the release branches) will automatically run the BDD tests in GitHub Actions. You can verify your code changes by moving to the 'Checks' tab in your pull request page, and checking the results of the 'integration-test' check.

--- a/tests/operations.go
+++ b/tests/operations.go
@@ -55,7 +55,7 @@ import (
 )
 
 const (
-	maxRetry = 60
+	maxRetry = 90
 )
 
 type bdcExitStatus string

--- a/tests/operations.go
+++ b/tests/operations.go
@@ -55,7 +55,7 @@ import (
 )
 
 const (
-	maxRetry = 90
+	maxRetry = 60
 )
 
 type bdcExitStatus string

--- a/tests/operations.go
+++ b/tests/operations.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+
 	//"sort"
 	"strconv"
 	"time"
@@ -54,7 +55,7 @@ import (
 )
 
 const (
-	maxRetry = 30
+	maxRetry = 60
 )
 
 type bdcExitStatus string


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

**Why is this PR required? What issue does it fix?**:
The integration tests are used to test new changes to the codebase. They should produce reliable results when run.

**What this PR does?**:
Changes the value of the maxRetry variable in tests/operations.go file. This extends the timeout duration for checks to a value greater than or equal to 5 minutes.

Using ginkgo cli, instead of go test to work around the default timeout at the 10m mark
Updated tests/README.md
Updated Minikube version and Kubernetes version for Minikube in CI.

**Does this PR require any upgrade changes?**:
No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:
N/A

**Any additional information for your reviewer?** : 
No.