### PR TITLE
fix(ci): avoid running localpv-e2e builds on release creation and build & push only on develop branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,6 +205,8 @@ jobs:
           make integration-test
 
   localpv-e2e:
+    # to ignore builds on release AND build only if the branch is develop
+    if: ${{ (github.event.ref_type != 'tag') && (github.ref == 'refs/heads/develop') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

This avoids running localpv-e2e job when a new release is created.
This triggers localpv-e2e image builds only if the branch is develop.

This can be tested by monitoring the Actions tab on this repo after this PR is merged.