### PR TITLE
refact(XFS-Quota): get XFS Quota parameters from StorageClass 'cas.openebs.io/config' annotation

### DIFF
--- a/cmd/provisioner-localpv/app/config.go
+++ b/cmd/provisioner-localpv/app/config.go
@@ -19,6 +19,7 @@ package app
 
 import (
 	"context"
+	"strconv"
 	"strings"
 
 	mconfig "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
@@ -113,6 +114,17 @@ const (
 	// is specified with PVC and is useful for granting shared access
 	// to underlying hostpaths across multiple pods.
 	//KeyPVAbsolutePath = "AbsolutePath"
+
+	//KeyXFSQuota enables/sets parameters for XFS Quota.
+	// Example StorageClass snippet:
+	//    - name: XFSQuota
+	//      enabled: true
+	//      data:
+	//        softLimitGrace: "80%"
+	//        hardLimitGrace: "85%"
+	KeyXFSQuota          = "XFSQuota"
+	KeyXfsQuotaSoftLimit = "softLimitGrace"
+	KeyXfsQuotaHardLimit = "hardLimitGrace"
 )
 
 const (
@@ -168,11 +180,17 @@ func (p *Provisioner) GetVolumeConfig(ctx context.Context, pvName string, pvc *c
 		return nil, errors.Wrapf(err, "unable to read volume config: pvc {%v}", pvc.ObjectMeta.Name)
 	}
 
+	dataPvConfigMap, err := dataConfigToMap(pvConfig)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to read volume config: pvc {%v}", pvc.ObjectMeta.Name)
+	}
+
 	c := &VolumeConfig{
-		pvName:  pvName,
-		pvcName: pvc.ObjectMeta.Name,
-		scName:  *scName,
-		options: pvConfigMap,
+		pvName:     pvName,
+		pvcName:    pvc.ObjectMeta.Name,
+		scName:     *scName,
+		options:    pvConfigMap,
+		configData: dataPvConfigMap,
 	}
 	return c, nil
 }
@@ -262,6 +280,32 @@ func (c *VolumeConfig) GetPath() (string, error) {
 		ValidateAndBuild()
 }
 
+func (c *VolumeConfig) IsXfsQuotaEnabled() bool {
+	xfsQuotaEnabled := c.getEnabled(KeyXFSQuota)
+	xfsQuotaEnabled = strings.TrimSpace(xfsQuotaEnabled)
+
+	enableXfsQuotaBool, err := strconv.ParseBool(xfsQuotaEnabled)
+	//Default case
+	// this means that we have hit either of the two cases below:
+	//     i. The value was something other than a straightforward
+	//        true or false
+	//    ii. The value was empty
+	if err != nil {
+		softLimit := strings.TrimSpace(c.getData(KeyXFSQuota, KeyXfsQuotaSoftLimit))
+		hardLimit := strings.TrimSpace(c.getData(KeyXFSQuota, KeyXfsQuotaHardLimit))
+		// Checking if XFS enabling is implied
+		// by the usage of 'KeyXfsQuotaSoftLimit' or
+		// 'KeyXfsQuotaHardLimit'
+		if len(softLimit) > 0 || len(hardLimit) > 0 {
+			return true
+		}
+
+		return false
+	}
+
+	return enableXfsQuotaBool
+}
+
 //getValue is a utility function to extract the value
 // of the `key` from the ConfigMap object - which is
 // map[string]interface{map[string][string]}
@@ -280,6 +324,30 @@ func (c *VolumeConfig) getValue(key string) string {
 			return val
 		}
 	}
+	return ""
+}
+
+//Similar to getValue() above. Returns value of the
+// 'Enabled' parameter.
+func (c *VolumeConfig) getEnabled(key string) string {
+	if configObj, ok := util.GetNestedField(c.options, key).(map[string]string); ok {
+		if val, p := configObj[string(mconfig.EnabledPTP)]; p {
+			return val
+		}
+	}
+	return ""
+}
+
+//This is similar to getValue() and getEnabled().
+// This gets the value for a specific
+// 'Data' parameter key-value pair.
+func (c *VolumeConfig) getData(key string, dataKey string) string {
+	if configData, ok := util.GetNestedField(c.configData, key).(map[string]string); ok {
+		if val, p := configData[dataKey]; p {
+			return val
+		}
+	}
+	//Default case
 	return ""
 }
 
@@ -346,4 +414,26 @@ func GetImagePullSecrets(s string) []corev1.LocalObjectReference {
 		}
 	}
 	return list
+}
+
+func dataConfigToMap(pvConfig []mconfig.Config) (map[string]interface{}, error) {
+	m := map[string]interface{}{}
+
+	for _, configObj := range pvConfig {
+		//No Data Parameter
+		if configObj.Data == nil {
+			continue
+		}
+
+		configName := strings.TrimSpace(configObj.Name)
+		confHierarchy := map[string]interface{}{
+			configName: configObj.Data,
+		}
+		isMerged := util.MergeMapOfObjects(m, confHierarchy)
+		if !isMerged {
+			return nil, errors.Errorf("failed to transform cas config 'Data' for configName '%s' to map: failed to merge: %s", configName, configObj)
+		}
+	}
+
+	return m, nil
 }

--- a/cmd/provisioner-localpv/app/config.go
+++ b/cmd/provisioner-localpv/app/config.go
@@ -291,15 +291,6 @@ func (c *VolumeConfig) IsXfsQuotaEnabled() bool {
 	//        true or false
 	//    ii. The value was empty
 	if err != nil {
-		softLimit := strings.TrimSpace(c.getData(KeyXFSQuota, KeyXfsQuotaSoftLimit))
-		hardLimit := strings.TrimSpace(c.getData(KeyXFSQuota, KeyXfsQuotaHardLimit))
-		// Checking if XFS enabling is implied
-		// by the usage of 'KeyXfsQuotaSoftLimit' or
-		// 'KeyXfsQuotaHardLimit'
-		if len(softLimit) > 0 || len(hardLimit) > 0 {
-			return true
-		}
-
 		return false
 	}
 

--- a/cmd/provisioner-localpv/app/helper_hostpath.go
+++ b/cmd/provisioner-localpv/app/helper_hostpath.go
@@ -109,8 +109,8 @@ func (pOpts *HelperPodOptions) validate() error {
 func (pOpts *HelperPodOptions) validateLimits() error {
 	if pOpts.softLimitGrace == "0k" &&
 		pOpts.hardLimitGrace == "0k" {
-
 		// Hack: using convertToK() style converstion
+		// TODO: Refactor this section of the code
 		pvcStorageInK := math.Ceil(float64(pOpts.pvcStorage) / 1000)
 		pvcStorageInKString := strconv.FormatFloat(pvcStorageInK, 'f', -1, 64) + "k"
 		pOpts.softLimitGrace, pOpts.hardLimitGrace = pvcStorageInKString, pvcStorageInKString

--- a/cmd/provisioner-localpv/app/provisioner.go
+++ b/cmd/provisioner-localpv/app/provisioner.go
@@ -80,7 +80,7 @@ func NewProvisioner(kubeClient *clientset.Clientset) (*Provisioner, error) {
 
 // SupportsBlock will be used by controller to determine if block mode is
 //  supported by the host path provisioner.
-func (p *Provisioner) SupportsBlock(ctx context.Context) bool {
+func (p *Provisioner) SupportsBlock(_ context.Context) bool {
 	return true
 }
 

--- a/cmd/provisioner-localpv/app/provisioner_hostpath.go
+++ b/cmd/provisioner-localpv/app/provisioner_hostpath.go
@@ -93,11 +93,9 @@ func (p *Provisioner) ProvisionHostPath(ctx context.Context, opts pvController.P
 		return nil, pvController.ProvisioningFinished, iErr
 	}
 
-	enableXfsQuota := opts.StorageClass.Parameters[EnableXfsQuota]
-
-	if enableXfsQuota == "true" {
-		softLimitGrace := opts.StorageClass.Parameters[SoftLimitGrace]
-		hardLimitGrace := opts.StorageClass.Parameters[HardLimitGrace]
+	if volumeConfig.IsXfsQuotaEnabled() {
+		softLimitGrace := volumeConfig.getData(KeyXFSQuota, KeyXfsQuotaSoftLimit)
+		hardLimitGrace := volumeConfig.getData(KeyXFSQuota, KeyXfsQuotaHardLimit)
 		pvcStorage := opts.PVC.Spec.Resources.Requests.Storage().Value()
 
 		podOpts := &HelperPodOptions{

--- a/cmd/provisioner-localpv/app/types.go
+++ b/cmd/provisioner-localpv/app/types.go
@@ -60,10 +60,11 @@ type Provisioner struct {
 //   },
 // }
 type VolumeConfig struct {
-	pvName  string
-	pvcName string
-	scName  string
-	options map[string]interface{}
+	pvName     string
+	pvcName    string
+	scName     string
+	options    map[string]interface{}
+	configData map[string]interface{}
 }
 
 // GetVolumeConfigFn allows to plugin a custom function

--- a/pkg/kubernetes/api/storage/v1/storageclass/build.go
+++ b/pkg/kubernetes/api/storage/v1/storageclass/build.go
@@ -199,6 +199,8 @@ func WithXfsQuota(softLimit, hardLimit string) StorageClassOption {
 				" parameters or Provisioner name.")
 		}
 
+		// TODO: Refactor this code
+
 		config := "- name: XFSQuota\n" +
 			"  enabled: \"true\"\n"
 

--- a/pkg/kubernetes/api/storage/v1/storageclass/build.go
+++ b/pkg/kubernetes/api/storage/v1/storageclass/build.go
@@ -199,20 +199,24 @@ func WithXfsQuota(softLimit, hardLimit string) StorageClassOption {
 				" parameters or Provisioner name.")
 		}
 
-		if !isValidXfsQuotaData(map[string]string{
-			KeyXfsQuotaSoftLimit: softLimit,
-			KeyXfsQuotaHardLimit: hardLimit,
-		}) {
-			return errors.New("Failed to set XFSQuota parameters. " +
-				"Invalid " + KeyXfsQuotaSoftLimit + " and " +
-				KeyXfsQuotaHardLimit + " values")
-		}
-
 		config := "- name: XFSQuota\n" +
-			"  enabled: \"true\"\n" +
-			"  data:\n" +
-			"    " + KeyXfsQuotaSoftLimit + ": \"" + softLimit + "\"\n" +
-			"    " + KeyXfsQuotaHardLimit + ": \"" + hardLimit + "\"\n"
+			"  enabled: \"true\"\n"
+
+		if len(softLimit) > 0 || len(hardLimit) > 0 {
+			if !isValidXfsQuotaData(map[string]string{
+				KeyXfsQuotaSoftLimit: softLimit,
+				KeyXfsQuotaHardLimit: hardLimit,
+			}) {
+				return errors.New("Failed to set XFSQuota parameters. " +
+					"Invalid " + KeyXfsQuotaSoftLimit + " and " +
+					KeyXfsQuotaHardLimit + " values")
+			}
+
+			config = config +
+				"  data:\n" +
+				"    " + KeyXfsQuotaSoftLimit + ": \"" + softLimit + "\"\n" +
+				"    " + KeyXfsQuotaHardLimit + ": \"" + hardLimit + "\"\n"
+		}
 
 		ok := writeOrAppendCASConfig(s, config)
 		if !ok {

--- a/pkg/kubernetes/api/storage/v1/storageclass/build.go
+++ b/pkg/kubernetes/api/storage/v1/storageclass/build.go
@@ -27,12 +27,17 @@ import (
 const (
 	localPVcasTypeValue = "local"
 
-	// Provisioner Name
+	//Provisioner Name
 	localPVprovisionerName = "openebs.io/local"
 
-	// The following are imported from mconfig at the moment
+	//The following are imported from mconfig at the moment
 	// CASConfigKey = "cas.openebs.io/config"
 	// CASTypeKey = "openebs.io/cas-type"
+
+	//These are from 'app' package
+	// cmd/provisioner-localpv/app/config.go
+	KeyXfsQuotaSoftLimit = "softLimitGrace"
+	KeyXfsQuotaHardLimit = "hardLimitGrace"
 )
 
 type StorageClassOption func(*storagev1.StorageClass) error
@@ -182,6 +187,37 @@ func WithDevice() StorageClassOption {
 			return errors.New("Failed to set StorageType parameter for Device.")
 		}
 
+		return nil
+	}
+}
+
+func WithXfsQuota(softLimit, hardLimit string) StorageClassOption {
+	return func(s *storagev1.StorageClass) error {
+		if !isCompatibleWithXfsQuota(s) {
+			return errors.New("Failed to set XFSQuota parameters. " +
+				"Invalid existing '" + string(mconfig.CASConfigKey) + "' annotation" +
+				" parameters or Provisioner name.")
+		}
+
+		if !isValidXfsQuotaData(map[string]string{
+			KeyXfsQuotaSoftLimit: softLimit,
+			KeyXfsQuotaHardLimit: hardLimit,
+		}) {
+			return errors.New("Failed to set XFSQuota parameters. " +
+				"Invalid " + KeyXfsQuotaSoftLimit + " and " +
+				KeyXfsQuotaHardLimit + " values")
+		}
+
+		config := "- name: XFSQuota\n" +
+			"  enabled: \"true\"\n" +
+			"  data:\n" +
+			"    " + KeyXfsQuotaSoftLimit + ": \"" + softLimit + "\"\n" +
+			"    " + KeyXfsQuotaHardLimit + ": \"" + hardLimit + "\"\n"
+
+		ok := writeOrAppendCASConfig(s, config)
+		if !ok {
+			return errors.New("Failed to set XFSQuota parameters")
+		}
 		return nil
 	}
 }

--- a/tests/hostpath_quota_test.go
+++ b/tests/hostpath_quota_test.go
@@ -214,7 +214,7 @@ var _ = Describe("TEST HOSTPATH XFS QUOTA LOCAL PV WITH XFS FILESYSTEM", func() 
 				}),
 				sc.WithLocalPV(),
 				sc.WithHostpath(xfsHostpathDir),
-				sc.WithXfsQuota("0%", "0%"),
+				sc.WithXfsQuota("", ""),
 				sc.WithVolumeBindingMode("WaitForFirstConsumer"),
 				sc.WithReclaimPolicy("Delete"),
 			)

--- a/tests/hostpath_quota_test.go
+++ b/tests/hostpath_quota_test.go
@@ -62,13 +62,9 @@ var _ = Describe("TEST HOSTPATH XFS QUOTA LOCAL PV WITH NON-XFS FILESYSTEM", fun
 				}),
 				sc.WithLocalPV(),
 				sc.WithHostpath(hostpathDir),
+				sc.WithXfsQuota("20%", "50%"),
 				sc.WithVolumeBindingMode("WaitForFirstConsumer"),
 				sc.WithReclaimPolicy("Delete"),
-				sc.WithParameters(map[string]string{
-					"enableXfsQuota": "true",
-					"softLimitGrace": "20%",
-					"hardLimitGrace": "50%",
-				}),
 			)
 			Expect(err).To(
 				BeNil(),
@@ -218,13 +214,9 @@ var _ = Describe("TEST HOSTPATH XFS QUOTA LOCAL PV WITH XFS FILESYSTEM", func() 
 				}),
 				sc.WithLocalPV(),
 				sc.WithHostpath(xfsHostpathDir),
+				sc.WithXfsQuota("0%", "0%"),
 				sc.WithVolumeBindingMode("WaitForFirstConsumer"),
 				sc.WithReclaimPolicy("Delete"),
-				sc.WithParameters(map[string]string{
-					"enableXfsQuota": "true",
-					"softLimitGrace": "0%",
-					"hardLimitGrace": "0%",
-				}),
 			)
 			Expect(err).To(
 				BeNil(),

--- a/tests/operations.go
+++ b/tests/operations.go
@@ -312,7 +312,7 @@ func (ops *Operations) IsPVCBoundEventually(pvcName string) bool {
 		Expect(err).ShouldNot(HaveOccurred())
 		return pvc.NewForAPIObject(volume).IsBound()
 	},
-		120, 10).
+		450, 5).
 		Should(BeTrue())
 }
 
@@ -326,7 +326,7 @@ func (ops *Operations) VerifyCapacity(pvcName, capacity string) bool {
 		desiredCapacity, _ := resource.ParseQuantity(capacity)
 		return (desiredCapacity.Cmp(actualCapacity) == 0)
 	},
-		120, 10).
+		450, 5).
 		Should(BeTrue())
 }
 
@@ -350,7 +350,7 @@ func (ops *Operations) IsPodRunningEventually(namespace, podName string) bool {
 		return pod.NewForAPIObject(p).
 			IsRunning()
 	},
-		150, 10).
+		450, 5).
 		Should(BeTrue())
 }
 
@@ -469,7 +469,7 @@ func (ops *Operations) IsPVCDeletedEventually(pvcName, namespace string) bool {
 			Get(context.TODO(), pvcName, metav1.GetOptions{})
 		return isNotFound(err)
 	},
-		120, 2).
+		450, 5).
 		Should(BeTrue())
 }
 
@@ -491,7 +491,7 @@ func (ops *Operations) IsPVDeletedEventually(pvName string) bool {
 			Get(context.TODO(), pvName, metav1.GetOptions{})
 		return isNotFound(err)
 	},
-		120, 2).
+		450, 5).
 		Should(BeTrue())
 }
 
@@ -503,7 +503,7 @@ func (ops *Operations) IsPodDeletedEventually(namespace, podName string) bool {
 			Get(context.TODO(), podName, metav1.GetOptions{})
 		return isNotFound(err)
 	},
-		120, 10).
+		450, 5).
 		Should(BeTrue())
 }
 
@@ -537,7 +537,7 @@ func (ops *Operations) IsBDCDeletedEventually(bdcName, namespace string) bool {
 			Get(context.TODO(), bdcName, metav1.GetOptions{})
 		return isNotFound(err)
 	},
-		120, 2).
+		450, 5).
 		Should(BeTrue())
 }
 

--- a/tests/operations.go
+++ b/tests/operations.go
@@ -55,7 +55,7 @@ import (
 )
 
 const (
-	maxRetry = 60
+	maxRetry = 90
 )
 
 type bdcExitStatus string


### PR DESCRIPTION
## Pull Request template

**Why is this PR required? What issue does it fix?**:
This PR makes code changes for XFS Quota so that it may use cas-config parameters instead of spec.Parameters.

**What this PR does?**:
Modifies volumeConfig struct to include a new map generated for the 'Data' field in Config object.
Adds functions to get values of Enabled and Data fields.
Adds a function and modifies existing code to use values from StorageClass's cas-config annotation.
Sample storageClass:
```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: openebs-hostpath-xfs
  annotations:
    openebs.io/cas-type: local
    cas.openebs.io/config: |
      - name: StorageType
        value: "hostpath"
      - name: BasePath
        value: "/var/openebs/local/"
      - name: XFSQuota
        enabled: "true"
        data:
          softLimitGrace: "80%"
          hardLimitGrace: "85%"
provisioner: openebs.io/local
volumeBindingMode: WaitForFirstConsumer
reclaimPolicy: Delete
```
This above may be used in place of the below StorageClass with similar configuration:
```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: openebs-hostpath-xfs
  annotations:
    openebs.io/cas-type: local
    cas.openebs.io/config: |
      - name: StorageType
        value: "hostpath"
      - name: BasePath
        value: "/var/openebs/local/"
provisioner: openebs.io/local
volumeBindingMode: WaitForFirstConsumer
reclaimPolicy: Delete
parameters:
  enableXfsQuota: 'true'
  softLimitGrace: "80%"
  hardLimitGrace: "85%"
```
-----------------------------------------

Sample StorageClass for when you want to enforce the PVC's `.spec.resources.requests.storage` value.
```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: openebs-hostpath-xfs
  annotations:
    openebs.io/cas-type: local
    cas.openebs.io/config: |
      - name: StorageType
        value: "hostpath"
      - name: BasePath
        value: "/var/openebs/local/"
      - name: XFSQuota
        enabled: "true"
provisioner: openebs.io/local
volumeBindingMode: WaitForFirstConsumer
reclaimPolicy: Delete
```