### PR TITLE
chore(operator-yaml): add NDM ChangeDetection flag + image tag standardisation

### DIFF
--- a/deploy/kubectl/openebs-operator-lite.yaml
+++ b/deploy/kubectl/openebs-operator-lite.yaml
@@ -525,14 +525,13 @@ spec:
       #hostPID: true
       containers:
       - name: node-disk-manager
-        image: openebs/node-disk-manager:ci
+        image: openebs/node-disk-manager:1.7.x-ci
         args:
           - -v=4
         # The feature-gate is used to enable the new UUID algorithm.
           - --feature-gates="GPTBasedUUID"
-        # Detect mount point and filesystem changes wihtout restart.
-        # Uncomment the line below to enable the feature.
-        # --feature-gates="MountChangeDetection"
+        # Detect changes to device size, filesystem and mount-points without restart.
+          - --feature-gates="ChangeDetection"
         # The feature gate is used to start the gRPC API service. The gRPC server
         # starts at 9115 port by default. This feature is currently in Alpha state
         # - --feature-gates="APIService"
@@ -643,7 +642,7 @@ spec:
       serviceAccountName: openebs-maya-operator
       containers:
         - name: node-disk-operator
-          image: openebs/node-disk-operator:ci
+          image: openebs/node-disk-operator:1.7.x-ci
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

Changes:
1.  Adds flag for ChangeDetection feature on NDM DaemonSet
2. Changes image tags as follows:
       i. node-disk-manager:ci --> node-disk-manager:1.7.x-ci
      ii. node-disk-operator:ci --> node-disk-operator:1.7.x-ci
