### PR TITLE
refact(integration-test): fix integration test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,12 +190,14 @@ jobs:
       - name: Set up Minikube
         uses: manusa/actions-setup-minikube@v2.4.2
         with:
-          minikube version: 'v1.23.0'
-          kubernetes version: 'v1.22.1'
+          minikube version: 'v1.23.2'
+          kubernetes version: 'v1.22.2'
           driver: none
+          start args: '--install-addons=false'
 
       - name: Set up infra for integration test
         run: |
+          sudo apt-get update && sudo apt-get install -y xfsprogs quota linux-modules-extra-azure
           go install github.com/onsi/ginkgo/ginkgo@v1.16.4
           sudo fallocate -l 2.5GiB /mnt/disk.img
           sed -e "/path-filter/{N;N;N;s|\"\"|\"$(sudo losetup -fP /mnt/disk.img --show)\"|}" -e '/path-filter/{N;N;N;N;s|/dev/loop,||}' -e '/openebs-provisioner-hostpath/{N;s/IfNotPresent/Never/}' deploy/kubectl/openebs-operator-lite.yaml | kubectl apply -f -

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,7 +191,7 @@ jobs:
         uses: manusa/actions-setup-minikube@v2.4.2
         with:
           minikube version: 'v1.23.2'
-          kubernetes version: 'v1.22.2'
+          kubernetes version: 'v1.22.3'
           driver: none
           start args: '--install-addons=false'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,7 +197,7 @@ jobs:
 
       - name: Set up infra for integration test
         run: |
-          sudo apt-get update && sudo apt-get install -y xfsprogs quota linux-modules-extra-azure
+          sudo apt-get update && sudo apt-get install -y xfsprogs quota linux-modules-extra-`uname -r`
           go install github.com/onsi/ginkgo/ginkgo@v1.16.4
           sudo fallocate -l 2.5GiB /mnt/disk.img
           sed -e "/path-filter/{N;N;N;s|\"\"|\"$(sudo losetup -fP /mnt/disk.img --show)\"|}" -e '/path-filter/{N;N;N;N;s|/dev/loop,||}' -e '/openebs-provisioner-hostpath/{N;s/IfNotPresent/Never/}' deploy/kubectl/openebs-operator-lite.yaml | kubectl apply -f -

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Set up infra for integration test
         run: |
-          sudo apt-get update && sudo apt-get install -y xfsprogs quota linux-modules-extra-azure
+          sudo apt-get update && sudo apt-get install -y xfsprogs quota linux-modules-extra-`uname -r`
           go install github.com/onsi/ginkgo/ginkgo@v1.16.4
           sudo fallocate -l 2.5GiB /mnt/disk.img
           sed -e "/path-filter/{N;N;N;s|\"\"|\"$(sudo losetup -fP /mnt/disk.img --show)\"|}" -e '/path-filter/{N;N;N;N;s|/dev/loop,||}' -e '/openebs-provisioner-hostpath/{N;s/IfNotPresent/Never/}' deploy/kubectl/openebs-operator-lite.yaml | kubectl apply -f -

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -126,7 +126,7 @@ jobs:
         uses: manusa/actions-setup-minikube@v2.4.2
         with:
           minikube version: 'v1.23.2'
-          kubernetes version: 'v1.22.2'
+          kubernetes version: 'v1.22.3'
           driver: none
           start args: '--install-addons=false'
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -125,12 +125,14 @@ jobs:
       - name: Set up Minikube
         uses: manusa/actions-setup-minikube@v2.4.2
         with:
-          minikube version: 'v1.23.0'
-          kubernetes version: 'v1.22.1'
+          minikube version: 'v1.23.2'
+          kubernetes version: 'v1.22.2'
           driver: none
+          start args: '--install-addons=false'
 
       - name: Set up infra for integration test
         run: |
+          sudo apt-get update && sudo apt-get install -y xfsprogs quota linux-modules-extra-azure
           go install github.com/onsi/ginkgo/ginkgo@v1.16.4
           sudo fallocate -l 2.5GiB /mnt/disk.img
           sed -e "/path-filter/{N;N;N;s|\"\"|\"$(sudo losetup -fP /mnt/disk.img --show)\"|}" -e '/path-filter/{N;N;N;N;s|/dev/loop,||}' -e '/openebs-provisioner-hostpath/{N;s/IfNotPresent/Never/}' deploy/kubectl/openebs-operator-lite.yaml | kubectl apply -f -

--- a/Makefile
+++ b/Makefile
@@ -142,17 +142,17 @@ testv: format
 # Requires KUBECONFIG env and Ginkgo binary
 .PHONY: integration-test
 integration-test:
-	@cd tests && ginkgo -v
+	@cd tests && sudo -E env "PATH=${PATH}" ginkgo -v -failFast
 
 # Requires KUBECONFIG env and Ginkgo binary
 .PHONY: device-integration-test
 device-integration-test:
-	@cd tests && ginkgo -v -skip="TEST HOSTPATH.*"
+	@cd tests && sudo -E env "PATH=${PATH}" ginkgo -v -failFast -skip="TEST HOSTPATH.*"
 
 # Requires KUBECONFIG env and Ginkgo binary
 .PHONY: hostpath-integration-test
 hostpath-integration-test:
-	@cd tests && ginkgo -v -focus="TEST HOSTPATH.*"
+	@cd tests && sudo -E env "PATH=${PATH}" ginkgo -v -failFast -focus="TEST HOSTPATH.*"
 
 .PHONY: format
 format:

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/openebs/dynamic-localpv-provisioner
 go 1.16
 
 require (
+	github.com/imdario/mergo v0.3.10 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/miekg/dns v1.1.35 // indirect
 	github.com/onsi/ginkgo v1.16.4
@@ -13,7 +14,9 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	go.uber.org/zap v1.17.0 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.22.0
 	k8s.io/apimachinery v0.22.0
 	k8s.io/client-go v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,9 @@ github.com/huandu/xstrings v1.3.1 h1:4jgBlKK6tLKFvO8u5pmYjG91cqytmDCDvGh7ECVFfFs
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
-github.com/imdario/mergo v0.3.8 h1:CGgOkSJeqMRmt0D9XLWExdT4m4F1vd3FV3VPt+0VxkQ=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/imdario/mergo v0.3.10 h1:6q5mVkdH/vYmqngx7kZQTjJ5HRsx+ImorDIEQ+beJgc=
+github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -627,8 +628,9 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
-google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.6 h1:lMO5rYAqUxkmaj76jAkRUvt5JZgFymx/+Q5Mzfivuhc=
+google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/pkg/kubernetes/api/core/v1/event/buildlist.go
+++ b/pkg/kubernetes/api/core/v1/event/buildlist.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package event
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+type ListBuilder struct {
+	list    *EventList
+	filters PredicateList
+}
+
+func ListBuilderFromAPIList(events *corev1.EventList) *ListBuilder {
+	b := &ListBuilder{list: &EventList{}}
+	if events == nil {
+		return b
+	}
+	for _, event := range events.Items {
+		event := event
+		b.list.Items = append(b.list.Items, &Event{Object: &event})
+	}
+	return b
+}
+
+// List returns the list of Event
+// instances that was built by this
+// builder
+func (b *ListBuilder) List() *EventList {
+	if b.filters == nil || len(b.filters) == 0 {
+		return b.list
+	}
+	filtered := &EventList{}
+	for _, event := range b.list.Items {
+		if b.filters.all(event) {
+			filtered.Items = append(filtered.Items, event)
+		}
+	}
+	return filtered
+}
+
+// WithFilter add filters on which the Event
+// has to be filtered
+func (b *ListBuilder) WithFilter(pred ...Predicate) *ListBuilder {
+	b.filters = append(b.filters, pred...)
+	return b
+}

--- a/pkg/kubernetes/api/core/v1/event/event.go
+++ b/pkg/kubernetes/api/core/v1/event/event.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package event
+
+import (
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Event holds the API's Event object
+type Event struct {
+	Object *corev1.Event
+}
+
+// EventList holds the list of API Event instances
+type EventList struct {
+	Items []*Event
+}
+
+// PredicateList holds a list of predicate
+type PredicateList []Predicate
+
+// Predicate defines an abstraction
+// to determine conditional checks
+// against the provided Event instance
+type Predicate func(*Event) bool
+
+// all returns true if all the predicates
+// succeed against the provided Event
+// instance
+func (l PredicateList) all(event *Event) bool {
+	for _, pred := range l {
+		if !pred(event) {
+			return false
+		}
+	}
+	return true
+}
+
+// Len returns the number of items present in the EventList
+// Note: Required for AscendingSortByLastTimestamp()
+// and DescendingSortByLastTimestamp()
+func (eventList *EventList) Len() int {
+	return len(eventList.Items)
+}
+
+// Swap swaps two *Event instances in the EventList
+// Note: Required for AscendingSortByLastTimestamp()
+// and DescendingSortByLastTimestamp()
+func (eventList *EventList) Swap(i, j int) {
+	eventList.Items[i], eventList.Items[j] = eventList.Items[j], eventList.Items[i]
+}
+
+// Checks if the object.LastTimestamp for the Event
+// instance at 'i' index was earlier than the one
+// for the Event at 'j' index
+// Note: Required for AscendingSortByLastTimestamp()
+// and DescendingSortByLastTimestamp()
+func (eventList *EventList) Less(i, j int) bool {
+	return eventList.Items[i].Object.LastTimestamp.Time.Before(eventList.Items[j].Object.LastTimestamp.Time)
+}
+
+// Sorts Events in the EventList starting with
+// the least recent one
+func (eventList *EventList) LatestLastSort() *EventList {
+	sort.Stable(eventList)
+	return eventList
+}
+
+// Sorts Events in the EventList starting with
+// the most recent one
+func (eventList *EventList) LatestFirstSort() *EventList {
+	sort.Stable(sort.Reverse(eventList))
+	return eventList
+}
+
+// isBdcEvent() returns 'true' if the Kind field
+// of the InvoledObject struct is BlockDeviceClaim
+func (event *Event) isBdcEvent() bool {
+	return event.Object.InvolvedObject.Kind == "BlockDeviceClaim"
+}
+
+// Returns a predicate from isBdcEvent() function
+func IsBdcEvent() Predicate {
+	return func(event *Event) bool {
+		return event.isBdcEvent()
+	}
+}
+
+// isBdEvent() returns 'true' if the Kind field
+// of the InvoledObject struct is BlockDevice
+func (event *Event) isBdEvent() bool {
+	return event.Object.InvolvedObject.Kind == "BlockDevice"
+}
+
+// Returns a predicate from isBdEvent() function
+func IsBdEvent() Predicate {
+	return func(event *Event) bool {
+		return event.isBdEvent()
+	}
+}
+
+// isPodEvent() returns 'true' if the Kind field
+// of the InvoledObject struct is Pod
+func (event *Event) isPodEvent() bool {
+	return event.Object.InvolvedObject.Kind == "Pod"
+}
+
+// Returns a predicate from isPodEvent() function
+func IsPodEvent() Predicate {
+	return func(event *Event) bool {
+		return event.isPodEvent()
+	}
+}
+
+// Queries the Reason field in the InvolvedObject
+// instance in the corev1.Event
+// for an exact match of the argument string
+func (event *Event) hasReason(reason string) bool {
+	return event.Object.Reason == reason
+}
+
+// Returns a predicate from hasReason() function
+func HasReason(reason string) Predicate {
+	return func(event *Event) bool {
+		return event.hasReason(reason)
+	}
+}
+
+// Queries the Message field in the InvolvedObject
+// instance in the corev1.Event
+// for substring that matches the argument string
+func (event *Event) hasStringInMessage(substr string) bool {
+	return strings.Contains(event.Object.Message, substr)
+}
+
+// Returns a predicate from hasMessage() function
+func HasStringInMessage(substr string) Predicate {
+	return func(event *Event) bool {
+		return event.hasStringInMessage(substr)
+	}
+}
+
+// Queries the Type field in the InvolvedObject
+// instance in the corev1.Event
+// for an exact match of the argument string
+func (event *Event) isType(typeVal string) bool {
+	return event.Object.Type == typeVal
+}
+
+// Returns a predicate from isType() function
+func IsType(typeVal string) Predicate {
+	return func(event *Event) bool {
+		return event.isType(typeVal)
+	}
+}

--- a/pkg/kubernetes/api/core/v1/event/event_test.go
+++ b/pkg/kubernetes/api/core/v1/event/event_test.go
@@ -1,0 +1,238 @@
+/*
+Copyright 2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package event
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsBdcEventPredicate(t *testing.T) {
+	tests := map[string]struct {
+		availableInvolvedObjectKind string
+		isBDCKind                   bool
+	}{
+		"Test1": {"BlockDeviceClaim", true},
+		"Test2": {"Pod", false},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			fakeEvent := &Event{Object: &corev1.Event{InvolvedObject: corev1.ObjectReference{Kind: test.availableInvolvedObjectKind}}}
+			ok := IsBdcEvent()(fakeEvent)
+			if ok != test.isBDCKind {
+				t.Fatalf("Test %v failed, Expected %s but got %v", name, "BlockDeviceClaim", fakeEvent.Object.InvolvedObject.Kind)
+			}
+		})
+	}
+}
+
+func TestIsBdEventPredicate(t *testing.T) {
+	tests := map[string]struct {
+		availableInvolvedObjectKind string
+		isBDKind                    bool
+	}{
+		"Test1": {"BlockDevice", true},
+		"Test2": {"Pod", false},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			fakeEvent := &Event{Object: &corev1.Event{InvolvedObject: corev1.ObjectReference{Kind: test.availableInvolvedObjectKind}}}
+			ok := IsBdEvent()(fakeEvent)
+			if ok != test.isBDKind {
+				t.Fatalf("Test %v failed, Expected %s but got %v", name, "BlockDevice", fakeEvent.Object.InvolvedObject.Kind)
+			}
+		})
+	}
+}
+
+func TestIsPodEventPredicate(t *testing.T) {
+	tests := map[string]struct {
+		availableInvolvedObjectKind string
+		isPodKind                   bool
+	}{
+		"Test1": {"BlockDeviceClaim", false},
+		"Test2": {"Pod", true},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			fakeEvent := &Event{Object: &corev1.Event{InvolvedObject: corev1.ObjectReference{Kind: test.availableInvolvedObjectKind}}}
+			ok := IsPodEvent()(fakeEvent)
+			if ok != test.isPodKind {
+				t.Fatalf("Test %v failed, Expected %s but got %v", name, "Pod", fakeEvent.Object.InvolvedObject.Kind)
+			}
+		})
+	}
+}
+
+func TestIsTypePredicate(t *testing.T) {
+	tests := map[string]struct {
+		availableType string
+		checkForType  string
+		isType        bool
+	}{
+		"Test1": {"Normal", "Normal", true},
+		"Test2": {"Normal", "Warning", false},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			fakeEvent := &Event{Object: &corev1.Event{Type: test.availableType}}
+			ok := IsType(test.checkForType)(fakeEvent)
+			if ok != test.isType {
+				t.Fatalf("Test %v failed, Expected %s but got %v", name, test.checkForType, fakeEvent.Object.Type)
+			}
+		})
+	}
+}
+
+func TestHasReasonPredicate(t *testing.T) {
+	tests := map[string]struct {
+		availableReason string
+		checkForReason  string
+		hasReason       bool
+	}{
+		"Test1": {"BlockDeviceReleased", "BlockDeviceReleased", true},
+		"Test2": {"BlockDeviceClaimBound", "BlockDeviceClaimed", false},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			fakeEvent := &Event{&corev1.Event{Reason: test.availableReason}}
+			ok := HasReason(test.checkForReason)(fakeEvent)
+			if ok != test.hasReason {
+				t.Fatalf("Test %v failed, Expected %v but got %v", name, test.availableReason, fakeEvent.Object.Reason)
+			}
+		})
+	}
+}
+
+func TestStringInMessagePredicate(t *testing.T) {
+	tests := map[string]struct {
+		availableMessage string
+		checkForString   string
+		hasString        bool
+	}{
+		"Test1": {"Released from BDC: bdc-pvc-080b002e-c345-4a3d-88ab-324c41d41819", "bdc-pvc-080b002e-c345-4a3d-88ab-324c41d41819", true},
+		"Test2": {"Released from BDC: bdc-pvc-080b002e-c345-4a3d-88ab-324c41d42000", "bdc-pvc-080b002e-c345-4a3d-88ab-324c41d41819", false},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			fakeEvent := &Event{&corev1.Event{Message: test.availableMessage}}
+			ok := HasStringInMessage(test.checkForString)(fakeEvent)
+			if ok != test.hasString {
+				t.Fatalf("Test %v failed, Expected %v but got %v", name, test.availableMessage, fakeEvent.Object.Message)
+			}
+		})
+	}
+}
+
+func TestLatestFirstSort(t *testing.T) {
+	tests := map[string]struct {
+		availableEvents []*Event
+		sortedOrder     []string
+	}{
+		"Test1": {
+			availableEvents: []*Event{
+				{
+					Object: &corev1.Event{
+						ObjectMeta:    metav1.ObjectMeta{Name: "Event 1"},
+						LastTimestamp: metav1.Unix(500, 0),
+					},
+				},
+				{
+					Object: &corev1.Event{
+						ObjectMeta:    metav1.ObjectMeta{Name: "Event 2"},
+						LastTimestamp: metav1.Unix(600, 0),
+					},
+				},
+				{
+					Object: &corev1.Event{
+						ObjectMeta:    metav1.ObjectMeta{Name: "Event 3"},
+						LastTimestamp: metav1.Unix(400, 0),
+					},
+				},
+			},
+			sortedOrder: []string{"Event 2", "Event 1", "Event 3"},
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			availableEventList := &EventList{Items: test.availableEvents}
+			resultEventList := availableEventList.LatestFirstSort()
+			var resultOrder []string
+			for _, event := range resultEventList.Items {
+				resultOrder = append(resultOrder, event.Object.Name)
+			}
+			if !reflect.DeepEqual(resultOrder, test.sortedOrder) {
+				t.Fatalf("Test %v failed, Expected %v but got %v", name, test.sortedOrder, resultOrder)
+			}
+		})
+	}
+}
+
+func TestLatestLastSort(t *testing.T) {
+	tests := map[string]struct {
+		availableEvents []*Event
+		sortedOrder     []string
+	}{
+		"Test1": {
+			availableEvents: []*Event{
+				{
+					Object: &corev1.Event{
+						ObjectMeta:    metav1.ObjectMeta{Name: "Event 1"},
+						LastTimestamp: metav1.Unix(500, 0),
+					},
+				},
+				{
+					Object: &corev1.Event{
+						ObjectMeta:    metav1.ObjectMeta{Name: "Event 2"},
+						LastTimestamp: metav1.Unix(600, 0),
+					},
+				},
+				{
+					Object: &corev1.Event{
+						ObjectMeta:    metav1.ObjectMeta{Name: "Event 3"},
+						LastTimestamp: metav1.Unix(400, 0),
+					},
+				},
+			},
+			sortedOrder: []string{"Event 3", "Event 1", "Event 2"},
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			availableEventList := &EventList{Items: test.availableEvents}
+			resultEventList := availableEventList.LatestLastSort()
+			var resultOrder []string
+			for _, event := range resultEventList.Items {
+				resultOrder = append(resultOrder, event.Object.Name)
+			}
+			if !reflect.DeepEqual(resultOrder, test.sortedOrder) {
+				t.Fatalf("Test %v failed, Expected %v but got %v", name, test.sortedOrder, resultOrder)
+			}
+		})
+	}
+}

--- a/pkg/kubernetes/api/core/v1/event/kubernetes.go
+++ b/pkg/kubernetes/api/core/v1/event/kubernetes.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package event
+
+import (
+	"context"
+
+	client "github.com/openebs/dynamic-localpv-provisioner/pkg/kubernetes/client"
+	errors "github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// getClientsetFn is a typed function that
+// abstracts fetching of clientset
+type getClientsetFn func() (*clientset.Clientset, error)
+
+// getClientsetFromPathFn is a typed function that
+// abstracts fetching of clientset from kubeConfigPath
+type getClientsetForPathFn func(kubeConfigPath string) (*clientset.Clientset, error)
+
+// getKubeConfigFn is a typed function that
+// abstracts fetching of config
+type getKubeConfigFn func() (*rest.Config, error)
+
+// getKubeConfigForPathFn is a typed function that
+// abstracts fetching of config from kubeConfigPath
+type getKubeConfigForPathFn func(kubeConfigPath string) (*rest.Config, error)
+
+// listFn is a typed function that abstracts
+// listing of Events
+type listFn func(ctx context.Context, cli *clientset.Clientset, namespace string, opts metav1.ListOptions) (*corev1.EventList, error)
+
+// KubeClient enables kubernetes API operations
+// on Event instance
+type KubeClient struct {
+	// clientset refers to Event clientset
+	// that will be responsible to
+	// make kubernetes API calls
+	clientset *clientset.Clientset
+
+	// namespace holds the namespace on which
+	// KubeClient has to operate
+	namespace string
+
+	// kubeConfig represents kubernetes config
+	kubeConfig *rest.Config
+
+	// kubeconfig path to get kubernetes clientset
+	kubeConfigPath string
+
+	// functions useful during mocking
+	getKubeConfig        getKubeConfigFn
+	getKubeConfigForPath getKubeConfigForPathFn
+	getClientset         getClientsetFn
+	getClientsetForPath  getClientsetForPathFn
+	list                 listFn
+}
+
+// KubeClientBuildOption defines the abstraction
+// to build a KubeClient instance
+type KubeClientBuildOption func(*KubeClient)
+
+// withDefaults sets the default options
+// of KubeClient instance
+func (k *KubeClient) withDefaults() {
+	if k.getKubeConfig == nil {
+		k.getKubeConfig = func() (config *rest.Config, err error) {
+			return client.New().Config()
+		}
+	}
+	if k.getKubeConfigForPath == nil {
+		k.getKubeConfigForPath = func(kubeConfigPath string) (
+			config *rest.Config, err error) {
+			return client.New(client.WithKubeConfigPath(kubeConfigPath)).
+				GetConfigForPathOrDirect()
+		}
+	}
+	if k.getClientset == nil {
+		k.getClientset = func() (clients *clientset.Clientset, err error) {
+			return client.New().Clientset()
+		}
+	}
+	if k.getClientsetForPath == nil {
+		k.getClientsetForPath = func(kubeConfigPath string) (
+			clients *clientset.Clientset, err error) {
+			return client.New(client.WithKubeConfigPath(kubeConfigPath)).Clientset()
+		}
+	}
+	if k.list == nil {
+		k.list = func(ctx context.Context, cli *clientset.Clientset,
+			namespace string, opts metav1.ListOptions) (*corev1.EventList, error) {
+			return cli.CoreV1().Events(namespace).List(ctx, opts)
+		}
+	}
+}
+
+// WithClientSet sets the kubernetes client against
+// the KubeClient instance
+func WithClientSet(c *clientset.Clientset) KubeClientBuildOption {
+	return func(k *KubeClient) {
+		k.clientset = c
+	}
+}
+
+// WithKubeConfigPath sets the kubeConfig path
+// against client instance
+func WithKubeConfigPath(path string) KubeClientBuildOption {
+	return func(k *KubeClient) {
+		k.kubeConfigPath = path
+	}
+}
+
+// NewKubeClient returns a new instance of KubeClient meant for
+// cstor volume replica operations
+func NewKubeClient(opts ...KubeClientBuildOption) *KubeClient {
+	k := &KubeClient{}
+	for _, o := range opts {
+		o(k)
+	}
+	k.withDefaults()
+	return k
+}
+
+// WithNamespace sets the kubernetes namespace against
+// the provided namespace
+func (k *KubeClient) WithNamespace(namespace string) *KubeClient {
+	k.namespace = namespace
+	return k
+}
+
+// WithKubeConfig sets the kubernetes config against
+// the KubeClient instance
+func (k *KubeClient) WithKubeConfig(config *rest.Config) *KubeClient {
+	k.kubeConfig = config
+	return k
+}
+
+func (k *KubeClient) getClientsetForPathOrDirect() (
+	*clientset.Clientset, error) {
+	if k.kubeConfigPath != "" {
+		return k.getClientsetForPath(k.kubeConfigPath)
+	}
+	return k.getClientset()
+}
+
+// getClientsetOrCached returns either a new instance
+// of kubernetes client or its cached copy
+func (k *KubeClient) getClientsetOrCached() (*clientset.Clientset, error) {
+	if k.clientset != nil {
+		return k.clientset, nil
+	}
+
+	cs, err := k.getClientsetForPathOrDirect()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get clientset")
+	}
+	k.clientset = cs
+	return k.clientset, nil
+}
+
+func (k *KubeClient) getKubeConfigForPathOrDirect() (*rest.Config, error) {
+	if k.kubeConfigPath != "" {
+		return k.getKubeConfigForPath(k.kubeConfigPath)
+	}
+	return k.getKubeConfig()
+}
+
+// getKubeConfigOrCached returns either a new instance
+// of kubernetes config or its cached copy
+func (k *KubeClient) getKubeConfigOrCached() (*rest.Config, error) {
+	if k.kubeConfig != nil {
+		return k.kubeConfig, nil
+	}
+
+	kc, err := k.getKubeConfigForPathOrDirect()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get kube config")
+	}
+	k.kubeConfig = kc
+	return k.kubeConfig, nil
+}
+
+// List returns a list of Event
+// instances present in kubernetes cluster
+func (k *KubeClient) List(ctx context.Context, opts metav1.ListOptions) (*corev1.EventList, error) {
+	cli, err := k.getClientsetOrCached()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to list Events")
+	}
+	return k.list(ctx, cli, k.namespace, opts)
+}

--- a/pkg/kubernetes/api/core/v1/event/kubernetes_test.go
+++ b/pkg/kubernetes/api/core/v1/event/kubernetes_test.go
@@ -1,0 +1,291 @@
+// Copyright © 2018-2020 The OpenEBS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package event
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+func fakeGetClientSetOk() (cli *clientset.Clientset, err error) {
+	return &clientset.Clientset{}, nil
+}
+
+func fakeListFnOk(ctx context.Context, cli *clientset.Clientset, namespace string, opts metav1.ListOptions) (*corev1.EventList, error) {
+	return &corev1.EventList{}, nil
+}
+
+func fakeListFnErr(ctx context.Context, cli *clientset.Clientset, namespace string, opts metav1.ListOptions) (*corev1.EventList, error) {
+	return &corev1.EventList{}, errors.New("some error")
+}
+
+func fakeSetClientset(k *KubeClient) {
+	k.clientset = &clientset.Clientset{}
+}
+
+func fakeSetNilClientset(k *KubeClient) {
+	k.clientset = nil
+}
+
+func fakeGetClientSetNil() (clientset *clientset.Clientset, err error) {
+	return nil, nil
+}
+
+func fakeGetClientSetErr() (clientset *clientset.Clientset, err error) {
+	return nil, errors.New("Some error")
+}
+
+func fakeClientSet(k *KubeClient) {}
+
+func fakeGetClientSetForPathOk(fakeConfigPath string) (cli *clientset.Clientset, err error) {
+	return &clientset.Clientset{}, nil
+}
+
+func fakeGetClientSetForPathErr(fakeConfigPath string) (cli *clientset.Clientset, err error) {
+	return nil, errors.New("fake error")
+}
+
+func TestWithDefaultOptions(t *testing.T) {
+	tests := map[string]struct {
+		kubeClient *KubeClient
+	}{
+		"T1": {&KubeClient{}},
+		"T2": {&KubeClient{
+			clientset:    nil,
+			getClientset: fakeGetClientSetOk,
+			list:         fakeListFnOk,
+		}},
+		"T3": {&KubeClient{
+			getClientset: fakeGetClientSetOk,
+			list:         nil,
+		}},
+		"T4": {&KubeClient{
+			getClientset: nil,
+			list:         fakeListFnOk,
+		}},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			mock.kubeClient.withDefaults()
+			if mock.kubeClient.list == nil {
+				t.Fatalf("test %q failed: expected list not to be empty", name)
+			}
+			if mock.kubeClient.getClientset == nil {
+				t.Fatalf("test %q failed: expected get clientset not to be empty", name)
+			}
+		})
+	}
+}
+
+func TestWithDefaultsForClientSetPath(t *testing.T) {
+	tests := map[string]struct {
+		getClientSetForPath getClientsetForPathFn
+	}{
+		"T1": {nil},
+		"T2": {fakeGetClientSetForPathOk},
+	}
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			fc := &KubeClient{
+				getClientsetForPath: mock.getClientSetForPath,
+			}
+			fc.withDefaults()
+			if fc.getClientsetForPath == nil {
+				t.Fatalf("test %q failed: expected getClientsetForPath not to be nil", name)
+			}
+		})
+	}
+}
+
+func TestGetClientSetForPathOrDirect(t *testing.T) {
+	tests := map[string]struct {
+		getClientSet        getClientsetFn
+		getClientSetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		isErr               bool
+	}{
+		// Positive tests
+		"Positive 1": {fakeGetClientSetNil, fakeGetClientSetForPathOk, "fake-path", false},
+		"Positive 2": {fakeGetClientSetOk, fakeGetClientSetForPathOk, "", false},
+		"Positive 3": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "fake-path", false},
+		"Positive 4": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "", false},
+
+		// Negative tests
+		"Negative 1": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "", true},
+		"Negative 2": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "fake-path", true},
+		"Negative 3": {fakeGetClientSetErr, fakeGetClientSetForPathErr, "fake-path", true},
+		"Negative 4": {fakeGetClientSetErr, fakeGetClientSetForPathErr, "", true},
+	}
+
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			fc := &KubeClient{
+				getClientset:        mock.getClientSet,
+				getClientsetForPath: mock.getClientSetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+			}
+			_, err := fc.getClientsetForPathOrDirect()
+			if mock.isErr && err == nil {
+				t.Fatalf("test %q failed : expected error not to be nil but got %v", name, err)
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("test %q failed : expected error be nil but got %v", name, err)
+			}
+		})
+	}
+}
+
+func TestWithClientsetBuildOption(t *testing.T) {
+	tests := map[string]struct {
+		Clientset             *clientset.Clientset
+		expectKubeClientEmpty bool
+	}{
+		"Clientset is empty":     {nil, true},
+		"Clientset is not empty": {&clientset.Clientset{}, false},
+	}
+
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			h := WithClientSet(mock.Clientset)
+			fake := &KubeClient{}
+			h(fake)
+			if mock.expectKubeClientEmpty && fake.clientset != nil {
+				t.Fatalf("test %q failed expected fake.clientset to be empty", name)
+			}
+			if !mock.expectKubeClientEmpty && fake.clientset == nil {
+				t.Fatalf("test %q failed expected fake.clientset not to be empty", name)
+			}
+		})
+	}
+}
+
+func TestKubeClientBuildOption(t *testing.T) {
+	tests := map[string]struct {
+		opts            []KubeClientBuildOption
+		expectClientSet bool
+	}{
+		"Positive 1": {[]KubeClientBuildOption{fakeSetClientset, WithKubeConfigPath("fake-path")}, true},
+		"Positive 2": {[]KubeClientBuildOption{fakeSetClientset, fakeClientSet}, true},
+		"Positive 3": {[]KubeClientBuildOption{fakeSetClientset, fakeClientSet, WithKubeConfigPath("fake-path")}, true},
+
+		"Negative 1": {[]KubeClientBuildOption{fakeSetNilClientset, WithKubeConfigPath("fake-path")}, false},
+		"Negative 2": {[]KubeClientBuildOption{fakeSetNilClientset, fakeClientSet}, false},
+		"Negative 3": {[]KubeClientBuildOption{fakeSetNilClientset, fakeClientSet, WithKubeConfigPath("fake-path")}, false},
+	}
+
+	for name, mock := range tests {
+		name, mock := name, mock
+		t.Run(name, func(t *testing.T) {
+			c := NewKubeClient(mock.opts...)
+			if !mock.expectClientSet && c.clientset != nil {
+				t.Fatalf("test %q failed expected fake.clientset to be empty", name)
+			}
+			if mock.expectClientSet && c.clientset == nil {
+				t.Fatalf("test %q failed expected fake.clientset not to be empty", name)
+			}
+		})
+	}
+}
+
+func TestGetClientOrCached(t *testing.T) {
+	tests := map[string]struct {
+		getClientSet        getClientsetFn
+		getClientSetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		expectErr           bool
+	}{
+		// Positive tests
+		"Positive 1": {fakeGetClientSetNil, fakeGetClientSetForPathOk, "fake-path", false},
+		"Positive 2": {fakeGetClientSetOk, fakeGetClientSetForPathOk, "", false},
+		"Positive 3": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "fake-path", false},
+		"Positive 4": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "", false},
+
+		// Negative tests
+		"Negative 1": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "", true},
+		"Negative 2": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "fake-path", true},
+		"Negative 3": {fakeGetClientSetErr, fakeGetClientSetForPathErr, "fake-path", true},
+		"Negative 4": {fakeGetClientSetErr, fakeGetClientSetForPathErr, "", true},
+	}
+
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		t.Run(name, func(t *testing.T) {
+			fc := &KubeClient{
+				getClientset:        mock.getClientSet,
+				getClientsetForPath: mock.getClientSetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+			}
+			_, err := fc.getClientsetOrCached()
+			if mock.expectErr && err == nil {
+				t.Fatalf("test %q failed : expected error not to be nil but got %v", name, err)
+			}
+			if !mock.expectErr && err != nil {
+				t.Fatalf("test %q failed : expected error be nil but got %v", name, err)
+			}
+		})
+	}
+}
+
+func TestKubernetesEventList(t *testing.T) {
+	tests := map[string]struct {
+		getClientset        getClientsetFn
+		getClientSetForPath getClientsetForPathFn
+		kubeConfigPath      string
+		list                listFn
+		expectErr           bool
+	}{
+		// Positive tests
+		"Positive 1": {fakeGetClientSetNil, fakeGetClientSetForPathOk, "fake-path", fakeListFnOk, false},
+		"Positive 2": {fakeGetClientSetOk, fakeGetClientSetForPathOk, "", fakeListFnOk, false},
+		"Positive 3": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "fake-path", fakeListFnOk, false},
+		"Positive 4": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "", fakeListFnOk, false},
+
+		// Negative tests
+		"Negative 1": {fakeGetClientSetErr, fakeGetClientSetForPathOk, "", fakeListFnOk, true},
+		"Negative 2": {fakeGetClientSetOk, fakeGetClientSetForPathErr, "fake-path", fakeListFnOk, true},
+		"Negative 3": {fakeGetClientSetErr, fakeGetClientSetForPathErr, "fake-path", fakeListFnOk, true},
+		"Negative 4": {fakeGetClientSetOk, fakeGetClientSetForPathOk, "", fakeListFnErr, true},
+	}
+
+	for name, mock := range tests {
+		name := name // pin it
+		mock := mock // pin it
+		t.Run(name, func(t *testing.T) {
+			fc := &KubeClient{
+				getClientset:        mock.getClientset,
+				getClientsetForPath: mock.getClientSetForPath,
+				kubeConfigPath:      mock.kubeConfigPath,
+				list:                mock.list,
+			}
+			_, err := fc.List(context.TODO(), metav1.ListOptions{})
+			if mock.expectErr && err == nil {
+				t.Fatalf("Test %q failed: expected error not to be nil", name)
+			}
+			if !mock.expectErr && err != nil {
+				t.Fatalf("Test %q failed: expected error to be nil", name)
+			}
+		})
+	}
+}

--- a/pkg/kubernetes/ndmconfig/ndmconfig.go
+++ b/pkg/kubernetes/ndmconfig/ndmconfig.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ndmconfig
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type Config struct {
+	ProbeConfigs  []ProbeConfig  `yaml:"probeconfigs,omitempty"`  // ProbeConfigs contains configs of Probes
+	FilterConfigs []FilterConfig `yaml:"filterconfigs,omitempty"` // FilterConfigs contains configs of Filters
+	TagConfigs    []TagConfig    `yaml:"tagconfigs,omitempty"`    // TagConfigs contains configs for tags
+}
+
+// ProbeConfig contains configs of Probe
+type ProbeConfig struct {
+	Key   string `yaml:"key"`   // Key is key for each Probe
+	Name  string `yaml:"name"`  // Name is name of Probe
+	State string `yaml:"state"` // State is state of Probe
+}
+
+// FilterConfig contains configs of Filter
+type FilterConfig struct {
+	Key     string `yaml:"key"`               // Key is key for each Filter
+	Name    string `yaml:"name"`              // Name is name of Filer
+	State   string `yaml:"state"`             // State is state of Filter
+	Include string `yaml:"include,omitempty"` // Include contains , separated values which we want to include for filter
+	Exclude string `yaml:"exclude,omitempty"` // Exclude contains , separated values which we want to exclude for filter
+}
+
+type TagConfig struct {
+	Name    string `yaml:"name,omitempty"`
+	Type    string `yaml:"type,omitempty"`
+	Pattern string `yaml:"pattern,omitempty"`
+	TagName string `yaml:"tag,omitempty"`
+}
+
+// Type of list -- include, exclude
+type ListType string
+
+const (
+	Include ListType = "include"
+	Exclude ListType = "exclude"
+)
+
+func NewConfigFromAPIConfigMap(ndmConfigMap *corev1.ConfigMap) (*Config, error) {
+	if ndmConfigMap == nil {
+		return nil, errors.New("NDM ConfigMap is 'nil'")
+	}
+
+	var c Config
+
+	ndmConfigString := ndmConfigMap.Data["node-disk-manager.config"]
+	err := yaml.Unmarshal([]byte(ndmConfigString), &c)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal NDM config")
+	}
+
+	return &c, nil
+}
+
+func (c *Config) AppendToPathFilter(listtype ListType, diskPath string) error {
+	if c == nil {
+		return errors.New("Config is nil")
+	}
+
+	var pathFilterIndex int
+	foundFlag := 0
+	for index, filterConfig := range c.FilterConfigs {
+		if filterConfig.Key == "path-filter" {
+			pathFilterIndex = index
+			foundFlag++
+			break
+		}
+	}
+	if foundFlag == 0 {
+		return errors.New("No filterconfig with 'key: path-filter' found")
+	}
+
+	separator := ""
+	switch listtype {
+	case Include:
+		if len(c.FilterConfigs[pathFilterIndex].Include) > 0 {
+			separator = ","
+		}
+		c.FilterConfigs[pathFilterIndex].Include = c.FilterConfigs[pathFilterIndex].Include + separator + diskPath
+		return nil
+	case Exclude:
+		if len(c.FilterConfigs[pathFilterIndex].Exclude) > 0 {
+			separator = ","
+		}
+		c.FilterConfigs[pathFilterIndex].Exclude = c.FilterConfigs[pathFilterIndex].Exclude + separator + diskPath
+		return nil
+	default:
+		return errors.New("invalid filterconfig path-filter list name")
+	}
+}
+
+func (c *Config) RemoveFromPathFilter(listtype ListType, diskPath string) error {
+	if c == nil {
+		return errors.New("Config is nil")
+	}
+
+	var pathFilterIndex int
+	foundFlag := 0
+	for index, filterConfig := range c.FilterConfigs {
+		if filterConfig.Key == "path-filter" {
+			pathFilterIndex = index
+			foundFlag++
+			break
+		}
+	}
+	if foundFlag == 0 {
+		return errors.New("No filterconfig with 'key: path-filter' found")
+	}
+
+	switch listtype {
+	case Include:
+		finalList := strings.ReplaceAll(c.FilterConfigs[pathFilterIndex].Include, ","+diskPath, "")
+		finalList = strings.ReplaceAll(finalList, diskPath, "")
+		c.FilterConfigs[pathFilterIndex].Include = finalList
+		return nil
+	case Exclude:
+		finalList := strings.ReplaceAll(c.FilterConfigs[pathFilterIndex].Exclude, ","+diskPath, "")
+		finalList = strings.ReplaceAll(finalList, diskPath, "")
+		c.FilterConfigs[pathFilterIndex].Exclude = finalList
+		return nil
+	default:
+		return errors.New("invalid filterconfig path-filter list name")
+	}
+}
+
+func (c *Config) GetConfigYaml() (string, error) {
+	if c == nil {
+		return "", errors.New("Config is nil")
+	}
+
+	yml, err := yaml.Marshal(c)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to marshal NDM Config to YAML")
+	}
+
+	return string(yml), nil
+}

--- a/pkg/kubernetes/ndmconfig/ndmconfig_test.go
+++ b/pkg/kubernetes/ndmconfig/ndmconfig_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ndmconfig
+
+import (
+	"testing"
+)
+
+func TestAppendToPathFilter(t *testing.T) {
+	tests := map[string]struct {
+		availableConfig     *Config
+		lisType             ListType
+		diskPath            string
+		expectedIncludeList string
+		expectedExcludeList string
+	}{
+		"append to non-empty include list": {
+			availableConfig:     &Config{FilterConfigs: []FilterConfig{{"path-filter", "path filter", "true", "/dev/loop1,/dev/loop2", ""}}},
+			lisType:             Include,
+			diskPath:            "/dev/loop9000",
+			expectedIncludeList: "/dev/loop1,/dev/loop2,/dev/loop9000",
+			expectedExcludeList: "",
+		},
+		"append to empty include list": {
+			availableConfig:     &Config{FilterConfigs: []FilterConfig{{"path-filter", "path filter", "true", "", ""}}},
+			lisType:             Include,
+			diskPath:            "/dev/loop9000",
+			expectedIncludeList: "/dev/loop9000",
+			expectedExcludeList: "",
+		},
+		"append to non-empty exclude list": {
+			availableConfig:     &Config{FilterConfigs: []FilterConfig{{"path-filter", "path filter", "true", "", "/dev/fd0,/dev/sr0,/dev/ram,/dev/dm-,/dev/md,/dev/rbd,/dev/zd"}}},
+			lisType:             Exclude,
+			diskPath:            "/dev/loop9000",
+			expectedIncludeList: "",
+			expectedExcludeList: "/dev/fd0,/dev/sr0,/dev/ram,/dev/dm-,/dev/md,/dev/rbd,/dev/zd,/dev/loop9000",
+		},
+		"append to empty exclude list": {
+			availableConfig:     &Config{FilterConfigs: []FilterConfig{{"path-filter", "path filter", "true", "", ""}}},
+			lisType:             Exclude,
+			diskPath:            "/dev/loop9000",
+			expectedIncludeList: "",
+			expectedExcludeList: "/dev/loop9000",
+		},
+	}
+
+	for name, test := range tests {
+		name := name
+		test := test
+		t.Run(name, func(t *testing.T) {
+			err := test.availableConfig.AppendToPathFilter(test.lisType, test.diskPath)
+
+			if err != nil ||
+				test.availableConfig.FilterConfigs[0].Include != test.expectedIncludeList ||
+				test.availableConfig.FilterConfigs[0].Exclude != test.expectedExcludeList {
+				t.Fatalf(
+					"Test %v failed, Expected 'include: %v' but got 'include: %v', "+
+						"Expected 'exclude: %v' but got 'exclude: %v'",
+					name,
+					test.expectedIncludeList, test.availableConfig.FilterConfigs[0].Include,
+					test.expectedExcludeList, test.availableConfig.FilterConfigs[0].Exclude,
+				)
+			}
+		})
+	}
+}
+
+func TestRemoveFromPathFilter(t *testing.T) {
+	tests := map[string]struct {
+		availableConfig     *Config
+		lisType             ListType
+		diskPath            string
+		expectedIncludeList string
+		expectedExcludeList string
+	}{
+		"remove from non-empty include list": {
+			availableConfig:     &Config{FilterConfigs: []FilterConfig{{"path-filter", "path filter", "true", "/dev/loop1,/dev/loop2,/dev/loop9000", ""}}},
+			lisType:             Include,
+			diskPath:            "/dev/loop9000",
+			expectedIncludeList: "/dev/loop1,/dev/loop2",
+			expectedExcludeList: "",
+		},
+		"remove from otherwise-empty include list": {
+			availableConfig:     &Config{FilterConfigs: []FilterConfig{{"path-filter", "path filter", "true", "/dev/loop9000", ""}}},
+			lisType:             Include,
+			diskPath:            "/dev/loop9000",
+			expectedIncludeList: "",
+			expectedExcludeList: "",
+		},
+		"remove from non-empty exclude list": {
+			availableConfig:     &Config{FilterConfigs: []FilterConfig{{"path-filter", "path filter", "true", "", "/dev/fd0,/dev/sr0,/dev/ram,/dev/dm-,/dev/md,/dev/rbd,/dev/zd,/dev/loop9000"}}},
+			lisType:             Exclude,
+			diskPath:            "/dev/loop9000",
+			expectedIncludeList: "",
+			expectedExcludeList: "/dev/fd0,/dev/sr0,/dev/ram,/dev/dm-,/dev/md,/dev/rbd,/dev/zd",
+		},
+		"remove from otherwise-empty exclude list": {
+			availableConfig:     &Config{FilterConfigs: []FilterConfig{{"path-filter", "path filter", "true", "", "/dev/loop9000"}}},
+			lisType:             Exclude,
+			diskPath:            "/dev/loop9000",
+			expectedIncludeList: "",
+			expectedExcludeList: "",
+		},
+	}
+
+	for name, test := range tests {
+		name := name
+		test := test
+		t.Run(name, func(t *testing.T) {
+			err := test.availableConfig.RemoveFromPathFilter(test.lisType, test.diskPath)
+
+			if err != nil ||
+				test.availableConfig.FilterConfigs[0].Include != test.expectedIncludeList ||
+				test.availableConfig.FilterConfigs[0].Exclude != test.expectedExcludeList {
+				t.Fatalf(
+					"Test %v failed, Expected 'include: %v' but got 'include: %v', "+
+						"Expected 'exclude: %v' but got 'exclude: %v'",
+					name,
+					test.expectedIncludeList, test.availableConfig.FilterConfigs[0].Include,
+					test.expectedExcludeList, test.availableConfig.FilterConfigs[0].Exclude,
+				)
+			}
+		})
+	}
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,8 +16,8 @@ Local PV Provisioner BDD tests are developed using ginkgo & gomega libraries.
   ```bash
   $ #For Ubuntu/Debian
   $ sudo apt-get update && sudo apt-get install -y xfsprogs quota linux-image-extra-virtual
-  $ ##For custom OS images, the kernel module package name may be different
-  $ ##E.g.: linux-modules-extra-aws, linux-modules-extra-azure 
+  $ ##The kernel module package name may be different depending on the OS image
+  $ ##E.g.: linux-modules-extra-`uname -r`
   $ #For CentOS/RHEL
   $ sudo yum install -y xfsprogs quota
   ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,12 +6,21 @@ Local PV Provisioner BDD tests are developed using ginkgo & gomega libraries.
 
 ### Pre-requisites
 
-- These tests are meant to be run in a single-node Kubernetes
-  cluster with one single available blockdevice (not mounted).
+- These tests are meant to be run in a single-node Kubernetes (v1.16+)
+  cluster with one single available blockdevice with no filesystem on
+  it (should not be mounted).
 
-- Some of the tests test features exclusive to the XFS filesystem.
-  To run the XFS tests, you will require the 'xfsprogs' package
-  installed on your node.
+- Some of the tests require the 'xfsprogs' and 'quota' packages to run.
+  For Ubuntu, you may need to install the quota_v2 kernel module. Install
+  the 'linux-image-extra-virtual' package to install the kernel module.
+  ```bash
+  $ #For Ubuntu/Debian
+  $ sudo apt-get update && sudo apt-get install -y xfsprogs quota linux-image-extra-virtual
+  $ ##For custom OS images, the kernel module package name may be different
+  $ ##E.g.: linux-modules-extra-aws, linux-modules-extra-azure 
+  $ #For CentOS/RHEL
+  $ sudo yum install -y xfsprogs quota
+  ```
 
 - You will require the Ginkgo binary to be able to run the tests.
   Install the latest Ginkgo binary using the following command:
@@ -40,18 +49,21 @@ Local PV Provisioner BDD tests are developed using ginkgo & gomega libraries.
 ### Run tests
 
 Run the tests by being in the localpv tests folder. 
-  ```bash
-  $ cd <repo-directory>/tests
-  $ ginkgo -v
- ```
-  In case the KUBECONFIG env is not configured, you can run:
- ```bash
-  $ ginkgo -v -- -kubeconfig=/path/to/kubeconfig
- ```
+>**Note:** The tests require privileges to create loop devices and to create
+directories in the '/var' directory.
+  
+```bash
+$ cd <repo-directory>/tests
+$ sudo -E env "PATH=$PATH" ginkgo -v
+```
+In case the KUBECONFIG env is not configured, you can run:
+```bash
+$ sudo -E env "PATH=$PATH" ginkgo -v -kubeconfig=/path/to/kubeconfig
+```
 
-  If your OpenEBS LocalPV components are in a different Kubernetes namespace than 'openebs', you may use the '-openebs-namespace' flag:
- ```bash
-  $ ginkgo -v -- -openebs-namespace=<your-namespace>
- ```
+If your OpenEBS LocalPV components are in a different Kubernetes namespace than 'openebs', you may use the '-openebs-namespace' flag:
+```bash
+$ sudo -E env "PATH=$PATH" ginkgo -v -openebs-namespace=<your-namespace>
+```
 
- > **Tip:** Raising a pull request to this repo's 'develop' branch (or any one of the release branches) will automatically run the BDD tests in GitHub Actions. You can verify your code changes by moving to the 'Checks' tab in your pull request page, and checking the results of the 'integration-test' check.
+>**Tip:** Raising a pull request to this repo's 'develop' branch (or any one of the release branches) will automatically run the BDD tests in GitHub Actions. You can verify your code changes by moving to the 'Checks' tab in your pull request page, and checking the results of the 'integration-test' check.

--- a/tests/disk/disk.go
+++ b/tests/disk/disk.go
@@ -268,19 +268,6 @@ func PrepareDisk(imgDir, hostPath string) (Disk, error) {
 		return physicalDisk, errors.Wrapf(err, "while creating loop back device with disk %+v", physicalDisk)
 	}
 
-	/*
-		// Make xfs fs on the created loopback device
-		err = physicalDisk.CreateFilesystem(fsType)
-		if err != nil {
-			return physicalDisk, errors.Wrapf(err, "while formatting the disk {%+v} with xfs fs", physicalDisk)
-		}
-
-		// Mount the xfs formatted loopback device
-		err = physicalDisk.PrjquotaMount(hostPath)
-		if err != nil {
-			return physicalDisk, errors.Wrapf(err, "while mounting the disk with pquota option {%+v}", physicalDisk)
-		}
-	*/
 	return physicalDisk, nil
 }
 

--- a/tests/disk/disk.go
+++ b/tests/disk/disk.go
@@ -247,11 +247,11 @@ func (disk *Disk) DetachAndDeleteDisk() error {
 func PrepareDisk(imgDir, hostPath string) (Disk, error) {
 	physicalDisk := NewDisk(DiskImageSize)
 
-	err := os.MkdirAll(imgDir, 0775)
+	err := os.MkdirAll(imgDir, 0750)
 	if err != nil {
 		return physicalDisk, errors.Wrapf(err, "while making a new directory at {%s}", imgDir)
 	}
-	err = os.MkdirAll(hostPath, 0775)
+	err = os.MkdirAll(hostPath, 0750)
 	if err != nil {
 		return physicalDisk, errors.Wrapf(err, "while making a new directory at {%s}", hostPath)
 	}

--- a/tests/disk/disk.go
+++ b/tests/disk/disk.go
@@ -129,7 +129,7 @@ func RunCommand(cmd string) ([]byte, error) {
 	args := substring[1:]
 	stdout, err := exec.Command(name, args...).CombinedOutput() // #nosec G204
 	if err != nil {
-		return stdout, fmt.Errorf("run failed, cmd={%s}\nerror={%v}\noutput={%v}", cmd, err, stdout)
+		return stdout, fmt.Errorf("run failed, cmd={%s}, error={%v}, output={%s}", cmd, err, string(stdout))
 	}
 	return stdout, err
 }

--- a/tests/hostdevice_test.go
+++ b/tests/hostdevice_test.go
@@ -754,16 +754,6 @@ var _ = Describe("[-ve] TEST HOSTDEVICE LOCAL PV", func() {
 				namespaceObj.Name,
 			)
 
-			/*
-				By("checking if BDC gets deleted")
-				staleBDCName := "bdc-pvc-" + string(pvcObj.GetUID())
-				exitStatus := ops.GetBDCStatusAfterAge(staleBDCName, openebsNamespace, time.Duration(bdcTimeoutDuration+1)*time.Second)
-				Expect(exitStatus).To(
-					Equal(deleted),
-					"while checking if the stale BDC {%s} got deleted",
-					staleBDCName,
-				)
-			*/
 			By("verifying pod count as 1")
 			podCount := ops.GetPodCountEventually(namespaceObj.Name, existinglabel, nil, 1)
 			Expect(podCount).To(Equal(1), "while verifying running pod count")

--- a/tests/hostdevice_test.go
+++ b/tests/hostdevice_test.go
@@ -85,6 +85,18 @@ var _ = Describe("TEST HOSTDEVICE LOCAL PV", func() {
 
 	When("PVC with StorageClass "+scName+" is created", func() {
 		It("should create a PVC ", func() {
+			By("verifying if NDM prerequisites are met")
+			Expect(ops.IsNdmPrerequisiteMet(
+				openebsNamespace,
+				ndmLabelSelector,
+				ndmOperatorLabelSelector,
+			)).To(
+				BeTrue(),
+				"when checking if NDM Pods are up and 1 "+
+					"Unclaimed and Active BlockDevice "+
+					"with no filesystem is present",
+			)
+
 			By("building a PVC")
 			pvcObj, err = pvc.NewBuilder().
 				WithName(pvcName).
@@ -189,11 +201,17 @@ var _ = Describe("TEST HOSTDEVICE LOCAL PV", func() {
 			err = ops.PodClient.WithNamespace(openebsNamespace).Delete(context.TODO(), podList.Items[0].Name, &metav1.DeleteOptions{})
 			Expect(err).To(BeNil())
 
+			podStatus := ops.IsPodDeletedEventually(openebsNamespace, podList.Items[0].Name)
+			Expect(podStatus).To(BeTrue(), "when checking if LocalPV Provisioner Pod was deleted")
+
+			podCount := ops.GetPodRunningCountEventually(openebsNamespace, LocalPVProvisionerLabelSelector, 1)
+			Expect(podCount).To(Equal(1))
+
 			Expect(ops.IsFinalizerExistsOnBDC(bdcName, localpv_app.LocalPVFinalizer)).To(BeTrue())
 		})
 	})
 	When("deployment is deleted", func() {
-		It("should not have any deployment or running pod", func() {
+		It("should not have any deployment or pod", func() {
 
 			By("deleting above deployment")
 			err = ops.DeployClient.WithNamespace(namespaceObj.Name).Delete(context.TODO(), deployName, &metav1.DeleteOptions{})
@@ -205,7 +223,7 @@ var _ = Describe("TEST HOSTDEVICE LOCAL PV", func() {
 			)
 
 			By("verifying pod count as 0")
-			podCount := ops.GetPodRunningCountEventually(namespaceObj.Name, label, 0)
+			podCount := ops.GetPodCountEventually(namespaceObj.Name, label, nil, 0)
 			Expect(podCount).To(Equal(0), "while verifying pod count")
 
 		})
@@ -213,11 +231,12 @@ var _ = Describe("TEST HOSTDEVICE LOCAL PV", func() {
 
 	When("PVC with StorageClass "+scName+" is deleted ", func() {
 		It("should delete the pvc", func() {
-			By("getting the PV name")
-			pvName := ops.GetPVNameFromPVCName(pvcName)
+			By("getting the PV name and the BD name")
+			pvName := ops.GetPVNameFromPVCName(namespaceObj.Name, pvcName)
+			bdName := ops.GetBDNameFromBDCName(bdcName, openebsNamespace)
 
 			By("deleting above pvc")
-			err = ops.PVCClient.Delete(context.TODO(), pvcName, &metav1.DeleteOptions{})
+			err = ops.PVCClient.WithNamespace(namespaceObj.Name).Delete(context.TODO(), pvcName, &metav1.DeleteOptions{})
 			Expect(err).To(
 				BeNil(),
 				"while deleting PVC {%s} in namespace {%s}",
@@ -241,8 +260,8 @@ var _ = Describe("TEST HOSTDEVICE LOCAL PV", func() {
 				pvcName,
 			)
 
-			By("verifying BDC is deleted")
-			status = ops.IsBDCDeletedEventually(bdcName, openebsNamespace)
+			By("verifying BD is cleaned up")
+			status = ops.IsBdCleanedUpEventually(openebsNamespace, bdName, bdcName)
 			Expect(status).To(
 				BeTrue(),
 				"when checking status of BDC {%s}, which should have been deleted",
@@ -262,6 +281,7 @@ var _ = Describe("TEST HOSTDEVICE LOCAL PV WITH VOLUMEMODE AS BLOCK", func() {
 		label         = "demo=hostdevice-deployment"
 		scNamePrefix  = "sc-hd-block"
 		scName        string
+		bdcName       string
 		pvcName       = "pvc-hd-block"
 		deployObj     *appsv1.Deployment
 		labelselector = map[string]string{
@@ -303,6 +323,18 @@ var _ = Describe("TEST HOSTDEVICE LOCAL PV WITH VOLUMEMODE AS BLOCK", func() {
 		It("should create a PVC ", func() {
 			var (
 				blockVolumeMode = corev1.PersistentVolumeBlock
+			)
+
+			By("verifying if NDM prerequisites are met")
+			Expect(ops.IsNdmPrerequisiteMet(
+				openebsNamespace,
+				ndmLabelSelector,
+				ndmOperatorLabelSelector,
+			)).To(
+				BeTrue(),
+				"when checking if NDM Pods are up and 1 "+
+					"Unclaimed and Active BlockDevice "+
+					"with no filesystem is present",
 			)
 
 			By("building a PVC")
@@ -395,7 +427,7 @@ var _ = Describe("TEST HOSTDEVICE LOCAL PV WITH VOLUMEMODE AS BLOCK", func() {
 
 	When("remove finalizer", func() {
 		It("finalizer should come back after provisioner restart", func() {
-			bdcName := "bdc-pvc-" + string(pvcObj.GetUID())
+			bdcName = "bdc-pvc-" + string(pvcObj.GetUID())
 			bdcObj, err := ops.BDCClient.WithNamespace(openebsNamespace).Get(context.TODO(), bdcName,
 				metav1.GetOptions{})
 			Expect(err).To(BeNil())
@@ -411,11 +443,17 @@ var _ = Describe("TEST HOSTDEVICE LOCAL PV WITH VOLUMEMODE AS BLOCK", func() {
 			err = ops.PodClient.WithNamespace(openebsNamespace).Delete(context.TODO(), podList.Items[0].Name, &metav1.DeleteOptions{})
 			Expect(err).To(BeNil())
 
+			podStatus := ops.IsPodDeletedEventually(openebsNamespace, podList.Items[0].Name)
+			Expect(podStatus).To(BeTrue(), "when checking if LocalPV Provisioner Pod was deleted")
+
+			podCount := ops.GetPodRunningCountEventually(openebsNamespace, LocalPVProvisionerLabelSelector, 1)
+			Expect(podCount).To(Equal(1))
+
 			Expect(ops.IsFinalizerExistsOnBDC(bdcName, localpv_app.LocalPVFinalizer)).To(BeTrue())
 		})
 	})
 	When("deployment is deleted", func() {
-		It("should not have any deployment or running pod", func() {
+		It("should not have any deployment or pod", func() {
 
 			By("deleting above deployment")
 			err = ops.DeployClient.WithNamespace(namespaceObj.Name).Delete(context.TODO(), deployName, &metav1.DeleteOptions{})
@@ -427,7 +465,7 @@ var _ = Describe("TEST HOSTDEVICE LOCAL PV WITH VOLUMEMODE AS BLOCK", func() {
 			)
 
 			By("verifying pod count as 0")
-			podCount := ops.GetPodRunningCountEventually(namespaceObj.Name, label, 0)
+			podCount := ops.GetPodCountEventually(namespaceObj.Name, label, nil, 0)
 			Expect(podCount).To(Equal(0), "while verifying pod count")
 
 		})
@@ -435,12 +473,12 @@ var _ = Describe("TEST HOSTDEVICE LOCAL PV WITH VOLUMEMODE AS BLOCK", func() {
 
 	When("PVC with StorageClass "+scName+" is deleted ", func() {
 		It("should delete the PVC", func() {
-			By("getting the PV name and the BDC name")
-			bdcName := "bdc-pvc-" + string(pvcObj.GetUID())
-			pvName := ops.GetPVNameFromPVCName(pvcName)
+			By("getting the PV name and the BD name")
+			pvName := ops.GetPVNameFromPVCName(namespaceObj.Name, pvcName)
+			bdName := ops.GetBDNameFromBDCName(bdcName, openebsNamespace)
 
 			By("deleting above pvc")
-			err = ops.PVCClient.Delete(context.TODO(), pvcName, &metav1.DeleteOptions{})
+			err = ops.PVCClient.WithNamespace(namespaceObj.Name).Delete(context.TODO(), pvcName, &metav1.DeleteOptions{})
 			Expect(err).To(
 				BeNil(),
 				"while deleting PVC {%s} in namespace {%s}",
@@ -464,8 +502,8 @@ var _ = Describe("TEST HOSTDEVICE LOCAL PV WITH VOLUMEMODE AS BLOCK", func() {
 				pvcName,
 			)
 
-			By("verifying BDC is deleted")
-			status = ops.IsBDCDeletedEventually(bdcName, openebsNamespace)
+			By("verifying BD is cleaned up")
+			status = ops.IsBdCleanedUpEventually(openebsNamespace, bdName, bdcName)
 			Expect(status).To(
 				BeTrue(),
 				"when checking status of BDC {%s}, which should have been deleted",
@@ -534,6 +572,17 @@ var _ = Describe("[-ve] TEST HOSTDEVICE LOCAL PV", func() {
 
 	When("existing PVC with StorageClass "+scName+" is created", func() {
 		It("should create a PVC", func() {
+			By("verifying if NDM prerequisites are met")
+			Expect(ops.IsNdmPrerequisiteMet(
+				openebsNamespace,
+				ndmLabelSelector,
+				ndmOperatorLabelSelector,
+			)).To(
+				BeTrue(),
+				"when checking if NDM Pods are up and 1 "+
+					"Unclaimed and Active BlockDevice "+
+					"with no filesystem is present",
+			)
 
 			By("building a pvc")
 			existingPVCObj, err = pvc.NewBuilder().
@@ -715,15 +764,19 @@ var _ = Describe("[-ve] TEST HOSTDEVICE LOCAL PV", func() {
 					staleBDCName,
 				)
 			*/
+			By("verifying pod count as 1")
+			podCount := ops.GetPodCountEventually(namespaceObj.Name, existinglabel, nil, 1)
+			Expect(podCount).To(Equal(1), "while verifying running pod count")
 
-			By("verifying pod count as 0")
-			podCount := ops.GetPodRunningCountEventually(namespaceObj.Name, label, 0)
-			Expect(podCount).To(Equal(0), "while verifying pod count")
+			By("verifying running pod count as 0")
+			//Giving the check time till timeout to try to get a running pod
+			podRunningCount := ops.GetPodRunningCountEventually(namespaceObj.Name, label, 1)
+			Expect(podRunningCount).To(Equal(0), "while verifying pod count")
 		})
 	})
 
 	When("above deployment is deleted", func() {
-		It("should not have any deployment or running pod", func() {
+		It("should not have any deployment or pod", func() {
 
 			By("deleting above deployment")
 			err = ops.DeployClient.WithNamespace(namespaceObj.Name).Delete(context.TODO(), deployName, &metav1.DeleteOptions{})
@@ -735,7 +788,7 @@ var _ = Describe("[-ve] TEST HOSTDEVICE LOCAL PV", func() {
 			)
 
 			By("verifying pod count as 0")
-			podCount := ops.GetPodRunningCountEventually(namespaceObj.Name, label, 0)
+			podCount := ops.GetPodCountEventually(namespaceObj.Name, label, nil, 0)
 			Expect(podCount).To(Equal(0), "while verifying pod count")
 
 		})
@@ -743,9 +796,11 @@ var _ = Describe("[-ve] TEST HOSTDEVICE LOCAL PV", func() {
 
 	When("above PVC with StorageClass "+scName+" is deleted ", func() {
 		It("should delete the PVC", func() {
+			By("getting the BDC name")
+			bdcName := "bdc-pvc-" + string(pvcObj.GetUID())
 
 			By("deleting above PVC")
-			err = ops.PVCClient.Delete(context.TODO(), pvcName, &metav1.DeleteOptions{})
+			err = ops.PVCClient.WithNamespace(namespaceObj.Name).Delete(context.TODO(), pvcName, &metav1.DeleteOptions{})
 			Expect(err).To(
 				BeNil(),
 				"while deleting PVC {%s} in namespace {%s}",
@@ -760,11 +815,19 @@ var _ = Describe("[-ve] TEST HOSTDEVICE LOCAL PV", func() {
 				"when checking status of deleted PVC {%s}",
 				pvcName,
 			)
+
+			By("veryfying BDC is deleted")
+			status = ops.IsBDCDeletedEventually(bdcName, openebsNamespace)
+			Expect(status).To(
+				BeTrue(),
+				"when checking status of BDC {%s}, which should have been deleted",
+				bdcName,
+			)
 		})
 	})
 
 	When("existing deployment is deleted", func() {
-		It("should not have any deployment or running pod", func() {
+		It("should not have any deployment or pod", func() {
 
 			By("deleting above deployment")
 			err = ops.DeployClient.WithNamespace(namespaceObj.Name).
@@ -777,20 +840,20 @@ var _ = Describe("[-ve] TEST HOSTDEVICE LOCAL PV", func() {
 			)
 
 			By("verifying pod count as 0")
-			podCount := ops.GetPodRunningCountEventually(namespaceObj.Name, existinglabel, 1)
-			Expect(podCount).To(Equal(1), "while verifying pod count")
-
+			podCount := ops.GetPodCountEventually(namespaceObj.Name, existinglabel, nil, 0)
+			Expect(podCount).To(Equal(0), "while verifying pod count")
 		})
 	})
 
 	When("existing PVC with storageclass "+scName+" is deleted ", func() {
 		It("should delete the PVC", func() {
-			By("getting the PV name and the BDC name")
+			By("getting the PV name, BD name and the BDC name")
 			bdcName := "bdc-pvc-" + string(existingPVCObj.GetUID())
-			pvName := ops.GetPVNameFromPVCName(existingPVCName)
+			pvName := ops.GetPVNameFromPVCName(namespaceObj.Name, existingPVCName)
+			bdName := ops.GetBDNameFromBDCName(bdcName, openebsNamespace)
 
 			By("deleting above PVC")
-			err = ops.PVCClient.Delete(context.TODO(), existingPVCName, &metav1.DeleteOptions{})
+			err = ops.PVCClient.WithNamespace(namespaceObj.Name).Delete(context.TODO(), existingPVCName, &metav1.DeleteOptions{})
 			Expect(err).To(
 				BeNil(),
 				"while deleting PVC {%s} in namespace {%s}",
@@ -814,14 +877,13 @@ var _ = Describe("[-ve] TEST HOSTDEVICE LOCAL PV", func() {
 				existingPVCName,
 			)
 
-			By("verifying BDC is deleted")
-			status = ops.IsBDCDeletedEventually(bdcName, openebsNamespace)
+			By("verifying BD is cleaned up")
+			status = ops.IsBdCleanedUpEventually(openebsNamespace, bdName, bdcName)
 			Expect(status).To(
 				BeTrue(),
 				"when checking status of BDC {%s}, which should have been deleted",
 				bdcName,
 			)
-
 		})
 	})
 })
@@ -884,6 +946,17 @@ var _ = Describe("[-ve] TEST HOSTDEVICE LOCAL PV WITH VOLUMEMODE AS BLOCK ", fun
 
 	When("existing PVC with StorageClass "+scName+" is created", func() {
 		It("should create a PVC", func() {
+			By("verifying if NDM prerequisites are met")
+			Expect(ops.IsNdmPrerequisiteMet(
+				openebsNamespace,
+				ndmLabelSelector,
+				ndmOperatorLabelSelector,
+			)).To(
+				BeTrue(),
+				"when checking if NDM Pods are up and 1 "+
+					"Unclaimed and Active BlockDevice "+
+					"with no filesystem is present",
+			)
 
 			By("building a PVC")
 			existingPVCObj, err = pvc.NewBuilder().
@@ -966,17 +1039,22 @@ var _ = Describe("[-ve] TEST HOSTDEVICE LOCAL PV WITH VOLUMEMODE AS BLOCK ", fun
 			)
 
 			By("verifying PVC status as bound")
-			status := ops.IsPVCBoundEventually(existingPVCName)
+			status := ops.IsPVCBoundEventually(namespaceObj.Name, existingPVCName)
 			Expect(status).To(Equal(true), "while checking status equal to bound")
 
-			By("verifying pod count as 0")
-			podCount := ops.GetPodRunningCountEventually(namespaceObj.Name, existinglabel, 1)
-			Expect(podCount).To(Equal(0), "while verifying pod count")
+			By("verifying pod count as 1")
+			podCount := ops.GetPodCountEventually(namespaceObj.Name, existinglabel, nil, 1)
+			Expect(podCount).To(Equal(1), "while verifying running pod count")
+
+			By("verifying running pod count as 0")
+			//Giving the check time till timeout to try to get a running pod
+			runningPodCount := ops.GetPodRunningCountEventually(namespaceObj.Name, existinglabel, 1)
+			Expect(runningPodCount).To(Equal(0), "while verifying running pod count")
 
 		})
 	})
 	When("above deployment is deleted", func() {
-		It("should not have any deployment or running pod", func() {
+		It("should not have any deployment or pod", func() {
 
 			By("deleting above deployment")
 			err = ops.DeployClient.WithNamespace(namespaceObj.Name).Delete(context.TODO(), existingDeployName, &metav1.DeleteOptions{})
@@ -988,7 +1066,7 @@ var _ = Describe("[-ve] TEST HOSTDEVICE LOCAL PV WITH VOLUMEMODE AS BLOCK ", fun
 			)
 
 			By("verifying pod count as 0")
-			podCount := ops.GetPodRunningCountEventually(namespaceObj.Name, existinglabel, 0)
+			podCount := ops.GetPodCountEventually(namespaceObj.Name, existinglabel, nil, 0)
 			Expect(podCount).To(Equal(0), "while verifying pod count")
 
 		})
@@ -996,9 +1074,13 @@ var _ = Describe("[-ve] TEST HOSTDEVICE LOCAL PV WITH VOLUMEMODE AS BLOCK ", fun
 
 	When("existing PVC with storageclass "+scName+" is deleted ", func() {
 		It("should delete the PVC", func() {
+			By("getting the PV name, BD name and the BDC name")
+			bdcName := "bdc-pvc-" + string(existingPVCObj.GetUID())
+			pvName := ops.GetPVNameFromPVCName(namespaceObj.Name, existingPVCName)
+			bdName := ops.GetBDNameFromBDCName(bdcName, openebsNamespace)
 
 			By("deleting above PVC")
-			err = ops.PVCClient.Delete(context.TODO(), existingPVCName, &metav1.DeleteOptions{})
+			err = ops.PVCClient.WithNamespace(namespaceObj.Name).Delete(context.TODO(), existingPVCName, &metav1.DeleteOptions{})
 			Expect(err).To(
 				BeNil(),
 				"while deleting PVC {%s} in namespace {%s}",
@@ -1006,14 +1088,29 @@ var _ = Describe("[-ve] TEST HOSTDEVICE LOCAL PV WITH VOLUMEMODE AS BLOCK ", fun
 				namespaceObj.Name,
 			)
 
+			By("having the Provisioner delete the PV")
+			status := ops.IsPVDeletedEventually(pvName)
+			Expect(status).To(
+				BeTrue(),
+				"while waiting for the Provisioner to delete PV {%s}",
+				pvName,
+			)
+
 			By("verifying PVC is deleted")
-			status := ops.IsPVCDeletedEventually(existingPVCName, namespaceObj.Name)
+			status = ops.IsPVCDeletedEventually(existingPVCName, namespaceObj.Name)
 			Expect(status).To(
 				BeTrue(),
 				"when checking status of deleted PVC {%s}",
 				existingPVCName,
 			)
 
+			By("verifying BD is cleaned up")
+			status = ops.IsBdCleanedUpEventually(openebsNamespace, bdName, bdcName)
+			Expect(status).To(
+				BeTrue(),
+				"when checking status of BDC {%s}, which should have been deleted",
+				bdcName,
+			)
 		})
 	})
 })

--- a/tests/hostpath_quota_test.go
+++ b/tests/hostpath_quota_test.go
@@ -148,15 +148,6 @@ var _ = Describe("TEST HOSTPATH XFS QUOTA LOCAL PV WITH NON-XFS FILESYSTEM", fun
 
 			By("verifying the pvc phase as pending")
 			Expect(createdPvc.Status.Phase).To(Equal(corev1.ClaimPending), "while verifying the pvc pending state")
-
-			By("verifying that the VolumeName is empty for the PVC")
-			pvName := ops.GetPVNameFromPVCName(namespaceObj.Name, pvcName)
-			Expect(pvName).To(
-				BeEmpty(),
-				"while getting Spec.VolumeName from PVC {%s} in namespace {%s}",
-				pvcName,
-				namespaceObj.Name,
-			)
 		})
 	})
 
@@ -179,6 +170,15 @@ var _ = Describe("TEST HOSTPATH XFS QUOTA LOCAL PV WITH NON-XFS FILESYSTEM", fun
 
 	When("pvc with storageclass "+scName+" is deleted", func() {
 		It("should delete the pvc", func() {
+			By("verifying that the VolumeName is empty for the PVC")
+			pvName := ops.GetPVNameFromPVCName(namespaceObj.Name, pvcName)
+			Expect(pvName).To(
+				BeEmpty(),
+				"while getting Spec.VolumeName from PVC {%s} in namespace {%s}",
+				pvcName,
+				namespaceObj.Name,
+			)
+
 			By("deleting above PVC")
 			err = ops.PVCClient.Delete(context.TODO(), pvcName, &metav1.DeleteOptions{})
 			Expect(err).To(

--- a/tests/hostpath_test.go
+++ b/tests/hostpath_test.go
@@ -170,7 +170,7 @@ var _ = Describe("TEST HOSTPATH LOCAL PV", func() {
 	})
 
 	When("deployment is deleted", func() {
-		It("should not have any deployment or running pod", func() {
+		It("should not have any deployment or pod", func() {
 
 			By("deleting above deployment")
 			err = ops.DeployClient.WithNamespace(namespaceObj.Name).Delete(context.TODO(), deployName, &metav1.DeleteOptions{})
@@ -182,7 +182,7 @@ var _ = Describe("TEST HOSTPATH LOCAL PV", func() {
 			)
 
 			By("verifying pod count as 0")
-			podCount := ops.GetPodRunningCountEventually(namespaceObj.Name, label, 0)
+			podCount := ops.GetPodCountEventually(namespaceObj.Name, label, nil, 0)
 			Expect(podCount).To(Equal(0), "while verifying pod count")
 
 		})
@@ -191,7 +191,7 @@ var _ = Describe("TEST HOSTPATH LOCAL PV", func() {
 	When("PVC with StorageClass "+scName+" is deleted ", func() {
 		It("should delete the PVC", func() {
 			By("getting the PV name from Bound PVC object spec")
-			pvName := ops.GetPVNameFromPVCName(pvcName)
+			pvName := ops.GetPVNameFromPVCName(namespaceObj.Name, pvcName)
 			Expect(pvName).ToNot(
 				BeEmpty(),
 				"while getting Spec.VolumeName from "+
@@ -201,7 +201,7 @@ var _ = Describe("TEST HOSTPATH LOCAL PV", func() {
 			)
 
 			By("deleting above PVC")
-			err = ops.PVCClient.Delete(context.TODO(), pvcName, &metav1.DeleteOptions{})
+			err = ops.PVCClient.WithNamespace(namespaceObj.Name).Delete(context.TODO(), pvcName, &metav1.DeleteOptions{})
 			Expect(err).To(
 				BeNil(),
 				"while deleting pvc {%s} in namespace {%s}",

--- a/vendor/github.com/imdario/mergo/.deepsource.toml
+++ b/vendor/github.com/imdario/mergo/.deepsource.toml
@@ -1,0 +1,12 @@
+version = 1
+
+test_patterns = [
+  "*_test.go"
+]
+
+[[analyzers]]
+name = "go"
+enabled = true
+
+  [analyzers.meta]
+  import_path = "github.com/imdario/mergo"

--- a/vendor/github.com/imdario/mergo/README.md
+++ b/vendor/github.com/imdario/mergo/README.md
@@ -2,6 +2,8 @@
 
 A helper to merge structs and maps in Golang. Useful for configuration default values, avoiding messy if-statements.
 
+Mergo merges same-type structs and maps by setting default values in zero-value fields. Mergo won't merge unexported (private) fields. It will do recursively any exported one. It also won't merge structs inside maps (because they are not addressable using Go reflection).
+
 Also a lovely [comune](http://en.wikipedia.org/wiki/Mergo) (municipality) in the Province of Ancona in the Italian region of Marche.
 
 ## Status
@@ -9,36 +11,37 @@ Also a lovely [comune](http://en.wikipedia.org/wiki/Mergo) (municipality) in the
 It is ready for production use. [It is used in several projects by Docker, Google, The Linux Foundation, VMWare, Shopify, etc](https://github.com/imdario/mergo#mergo-in-the-wild).
 
 [![GoDoc][3]][4]
-[![GoCard][5]][6]
+[![GitHub release][5]][6]
+[![GoCard][7]][8]
 [![Build Status][1]][2]
-[![Coverage Status][7]][8]
-[![Sourcegraph][9]][10]
+[![Coverage Status][9]][10]
+[![Sourcegraph][11]][12]
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fimdario%2Fmergo.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fimdario%2Fmergo?ref=badge_shield)
 
 [1]: https://travis-ci.org/imdario/mergo.png
 [2]: https://travis-ci.org/imdario/mergo
 [3]: https://godoc.org/github.com/imdario/mergo?status.svg
 [4]: https://godoc.org/github.com/imdario/mergo
-[5]: https://goreportcard.com/badge/imdario/mergo
-[6]: https://goreportcard.com/report/github.com/imdario/mergo
-[7]: https://coveralls.io/repos/github/imdario/mergo/badge.svg?branch=master
-[8]: https://coveralls.io/github/imdario/mergo?branch=master
-[9]: https://sourcegraph.com/github.com/imdario/mergo/-/badge.svg
-[10]: https://sourcegraph.com/github.com/imdario/mergo?badge
-
-### Latest release
-
-[Release v0.3.7](https://github.com/imdario/mergo/releases/tag/v0.3.7).
+[5]: https://img.shields.io/github/release/imdario/mergo.svg
+[6]: https://github.com/imdario/mergo/releases
+[7]: https://goreportcard.com/badge/imdario/mergo
+[8]: https://goreportcard.com/report/github.com/imdario/mergo
+[9]: https://coveralls.io/repos/github/imdario/mergo/badge.svg?branch=master
+[10]: https://coveralls.io/github/imdario/mergo?branch=master
+[11]: https://sourcegraph.com/github.com/imdario/mergo/-/badge.svg
+[12]: https://sourcegraph.com/github.com/imdario/mergo?badge
 
 ### Important note
 
-Please keep in mind that in [0.3.2](//github.com/imdario/mergo/releases/tag/0.3.2) Mergo changed `Merge()`and `Map()` signatures to support [transformers](#transformers). An optional/variadic argument has been added, so it won't break existing code.
+Please keep in mind that a problematic PR broke [0.3.9](//github.com/imdario/mergo/releases/tag/0.3.9). I reverted it in [0.3.10](//github.com/imdario/mergo/releases/tag/0.3.10), and I consider it stable but not bug-free. Also, this version adds suppot for go modules.
 
-If you were using Mergo **before** April 6th 2015, please check your project works as intended after updating your local copy with ```go get -u github.com/imdario/mergo```. I apologize for any issue caused by its previous behavior and any future bug that Mergo could cause (I hope it won't!) in existing projects after the change (release 0.2.0).
+Keep in mind that in [0.3.2](//github.com/imdario/mergo/releases/tag/0.3.2), Mergo changed `Merge()`and `Map()` signatures to support [transformers](#transformers). I added an optional/variadic argument so that it won't break the existing code.
+
+If you were using Mergo before April 6th, 2015, please check your project works as intended after updating your local copy with ```go get -u github.com/imdario/mergo```. I apologize for any issue caused by its previous behavior and any future bug that Mergo could cause in existing projects after the change (release 0.2.0).
 
 ### Donations
 
-If Mergo is useful to you, consider buying me a coffee, a beer or making a monthly donation so I can keep building great free software. :heart_eyes:
+If Mergo is useful to you, consider buying me a coffee, a beer, or making a monthly donation to allow me to keep building great free software. :heart_eyes:
 
 <a href='https://ko-fi.com/B0B58839' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://az743702.vo.msecnd.net/cdn/kofi1.png?v=0' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
 [![Beerpay](https://beerpay.io/imdario/mergo/badge.svg)](https://beerpay.io/imdario/mergo)
@@ -87,8 +90,9 @@ If Mergo is useful to you, consider buying me a coffee, a beer or making a month
 - [mantasmatelis/whooplist-server](https://github.com/mantasmatelis/whooplist-server)
 - [jnuthong/item_search](https://github.com/jnuthong/item_search)
 - [bukalapak/snowboard](https://github.com/bukalapak/snowboard)
+- [janoszen/containerssh](https://github.com/janoszen/containerssh)
 
-## Installation
+## Install
 
     go get github.com/imdario/mergo
 
@@ -99,7 +103,7 @@ If Mergo is useful to you, consider buying me a coffee, a beer or making a month
 
 ## Usage
 
-You can only merge same-type structs with exported fields initialized as zero value of their type and same-types maps. Mergo won't merge unexported (private) fields but will do recursively any exported one. It won't merge empty structs value as [they are not considered zero values](https://golang.org/ref/spec#The_zero_value) either. Also maps will be merged recursively except for structs inside maps (because they are not addressable using Go reflection).
+You can only merge same-type structs with exported fields initialized as zero value of their type and same-types maps. Mergo won't merge unexported (private) fields but will do recursively any exported one. It won't merge empty structs value as [they are zero values](https://golang.org/ref/spec#The_zero_value) too. Also, maps will be merged recursively except for structs inside maps (because they are not addressable using Go reflection).
 
 ```go
 if err := mergo.Merge(&dst, src); err != nil {
@@ -125,9 +129,7 @@ if err := mergo.Map(&dst, srcMap); err != nil {
 
 Warning: if you map a struct to map, it won't do it recursively. Don't expect Mergo to map struct members of your struct as `map[string]interface{}`. They will be just assigned as values.
 
-More information and examples in [godoc documentation](http://godoc.org/github.com/imdario/mergo).
-
-### Nice example
+Here is a nice example:
 
 ```go
 package main
@@ -175,10 +177,10 @@ import (
         "time"
 )
 
-type timeTransfomer struct {
+type timeTransformer struct {
 }
 
-func (t timeTransfomer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+func (t timeTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
 	if typ == reflect.TypeOf(time.Time{}) {
 		return func(dst, src reflect.Value) error {
 			if dst.CanSet() {
@@ -202,7 +204,7 @@ type Snapshot struct {
 func main() {
 	src := Snapshot{time.Now()}
 	dest := Snapshot{}
-	mergo.Merge(&dest, src, mergo.WithTransformers(timeTransfomer{}))
+	mergo.Merge(&dest, src, mergo.WithTransformers(timeTransformer{}))
 	fmt.Println(dest)
 	// Will print
 	// { 2018-01-12 01:15:00 +0000 UTC m=+0.000000001 }

--- a/vendor/github.com/imdario/mergo/doc.go
+++ b/vendor/github.com/imdario/mergo/doc.go
@@ -4,41 +4,140 @@
 // license that can be found in the LICENSE file.
 
 /*
-Package mergo merges same-type structs and maps by setting default values in zero-value fields.
+A helper to merge structs and maps in Golang. Useful for configuration default values, avoiding messy if-statements.
 
-Mergo won't merge unexported (private) fields but will do recursively any exported one. It also won't merge structs inside maps (because they are not addressable using Go reflection).
+Mergo merges same-type structs and maps by setting default values in zero-value fields. Mergo won't merge unexported (private) fields. It will do recursively any exported one. It also won't merge structs inside maps (because they are not addressable using Go reflection).
+
+Status
+
+It is ready for production use. It is used in several projects by Docker, Google, The Linux Foundation, VMWare, Shopify, etc.
+
+Important note
+
+Please keep in mind that a problematic PR broke 0.3.9. We reverted it in 0.3.10. We consider 0.3.10 as stable but not bug-free. . Also, this version adds suppot for go modules.
+
+Keep in mind that in 0.3.2, Mergo changed Merge() and Map() signatures to support transformers. We added an optional/variadic argument so that it won't break the existing code.
+
+If you were using Mergo before April 6th, 2015, please check your project works as intended after updating your local copy with go get -u github.com/imdario/mergo. I apologize for any issue caused by its previous behavior and any future bug that Mergo could cause in existing projects after the change (release 0.2.0).
+
+Install
+
+Do your usual installation procedure:
+
+    go get github.com/imdario/mergo
+
+    // use in your .go code
+    import (
+        "github.com/imdario/mergo"
+    )
 
 Usage
 
-From my own work-in-progress project:
+You can only merge same-type structs with exported fields initialized as zero value of their type and same-types maps. Mergo won't merge unexported (private) fields but will do recursively any exported one. It won't merge empty structs value as they are zero values too. Also, maps will be merged recursively except for structs inside maps (because they are not addressable using Go reflection).
 
-	type networkConfig struct {
-		Protocol string
-		Address string
-		ServerType string `json: "server_type"`
-		Port uint16
+	if err := mergo.Merge(&dst, src); err != nil {
+		// ...
 	}
 
-	type FssnConfig struct {
-		Network networkConfig
+Also, you can merge overwriting values using the transformer WithOverride.
+
+	if err := mergo.Merge(&dst, src, mergo.WithOverride); err != nil {
+		// ...
 	}
 
-	var fssnDefault = FssnConfig {
-		networkConfig {
-			"tcp",
-			"127.0.0.1",
-			"http",
-			31560,
-		},
+Additionally, you can map a map[string]interface{} to a struct (and otherwise, from struct to map), following the same restrictions as in Merge(). Keys are capitalized to find each corresponding exported field.
+
+	if err := mergo.Map(&dst, srcMap); err != nil {
+		// ...
 	}
 
-	// Inside a function [...]
+Warning: if you map a struct to map, it won't do it recursively. Don't expect Mergo to map struct members of your struct as map[string]interface{}. They will be just assigned as values.
 
-	if err := mergo.Merge(&config, fssnDefault); err != nil {
-		log.Fatal(err)
+Here is a nice example:
+
+	package main
+
+	import (
+		"fmt"
+		"github.com/imdario/mergo"
+	)
+
+	type Foo struct {
+		A string
+		B int64
 	}
 
-	// More code [...]
+	func main() {
+		src := Foo{
+			A: "one",
+			B: 2,
+		}
+		dest := Foo{
+			A: "two",
+		}
+		mergo.Merge(&dest, src)
+		fmt.Println(dest)
+		// Will print
+		// {two 2}
+	}
+
+Transformers
+
+Transformers allow to merge specific types differently than in the default behavior. In other words, now you can customize how some types are merged. For example, time.Time is a struct; it doesn't have zero value but IsZero can return true because it has fields with zero value. How can we merge a non-zero time.Time?
+
+	package main
+
+	import (
+		"fmt"
+		"github.com/imdario/mergo"
+			"reflect"
+			"time"
+	)
+
+	type timeTransformer struct {
+	}
+
+	func (t timeTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+		if typ == reflect.TypeOf(time.Time{}) {
+			return func(dst, src reflect.Value) error {
+				if dst.CanSet() {
+					isZero := dst.MethodByName("IsZero")
+					result := isZero.Call([]reflect.Value{})
+					if result[0].Bool() {
+						dst.Set(src)
+					}
+				}
+				return nil
+			}
+		}
+		return nil
+	}
+
+	type Snapshot struct {
+		Time time.Time
+		// ...
+	}
+
+	func main() {
+		src := Snapshot{time.Now()}
+		dest := Snapshot{}
+		mergo.Merge(&dest, src, mergo.WithTransformers(timeTransformer{}))
+		fmt.Println(dest)
+		// Will print
+		// { 2018-01-12 01:15:00 +0000 UTC m=+0.000000001 }
+	}
+
+Contact me
+
+If I can help you, you have an idea or you are using Mergo in your projects, don't hesitate to drop me a line (or a pull request): https://twitter.com/im_dario
+
+About
+
+Written by Dario Castañé: https://da.rio.hn
+
+License
+
+BSD 3-Clause license, as Go language.
 
 */
 package mergo

--- a/vendor/github.com/imdario/mergo/go.mod
+++ b/vendor/github.com/imdario/mergo/go.mod
@@ -1,0 +1,5 @@
+module github.com/imdario/mergo
+
+go 1.13
+
+require gopkg.in/yaml.v2 v2.3.0

--- a/vendor/github.com/imdario/mergo/go.sum
+++ b/vendor/github.com/imdario/mergo/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/vendor/github.com/imdario/mergo/map.go
+++ b/vendor/github.com/imdario/mergo/map.go
@@ -141,6 +141,9 @@ func MapWithOverwrite(dst, src interface{}, opts ...func(*Config)) error {
 }
 
 func _map(dst, src interface{}, opts ...func(*Config)) error {
+	if dst != nil && reflect.ValueOf(dst).Kind() != reflect.Ptr {
+		return ErrNonPointerAgument
+	}
 	var (
 		vDst, vSrc reflect.Value
 		err        error

--- a/vendor/github.com/imdario/mergo/merge.go
+++ b/vendor/github.com/imdario/mergo/merge.go
@@ -13,16 +13,28 @@ import (
 	"reflect"
 )
 
-func hasExportedField(dst reflect.Value) (exported bool) {
+func hasMergeableFields(dst reflect.Value) (exported bool) {
 	for i, n := 0, dst.NumField(); i < n; i++ {
 		field := dst.Type().Field(i)
 		if field.Anonymous && dst.Field(i).Kind() == reflect.Struct {
-			exported = exported || hasExportedField(dst.Field(i))
-		} else {
+			exported = exported || hasMergeableFields(dst.Field(i))
+		} else if isExportedComponent(&field) {
 			exported = exported || len(field.PkgPath) == 0
 		}
 	}
 	return
+}
+
+func isExportedComponent(field *reflect.StructField) bool {
+	pkgPath := field.PkgPath
+	if len(pkgPath) > 0 {
+		return false
+	}
+	c := field.Name[0]
+	if 'a' <= c && c <= 'z' || c == '_' {
+		return false
+	}
+	return true
 }
 
 type Config struct {
@@ -32,6 +44,8 @@ type Config struct {
 	Transformers                 Transformers
 	overwriteWithEmptyValue      bool
 	overwriteSliceWithEmptyValue bool
+	sliceDeepCopy                bool
+	debug                        bool
 }
 
 type Transformers interface {
@@ -46,7 +60,7 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 	typeCheck := config.TypeCheck
 	overwriteWithEmptySrc := config.overwriteWithEmptyValue
 	overwriteSliceWithEmptySrc := config.overwriteSliceWithEmptyValue
-	config.overwriteWithEmptyValue = false
+	sliceDeepCopy := config.sliceDeepCopy
 
 	if !src.IsValid() {
 		return
@@ -74,14 +88,14 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 
 	switch dst.Kind() {
 	case reflect.Struct:
-		if hasExportedField(dst) {
+		if hasMergeableFields(dst) {
 			for i, n := 0, dst.NumField(); i < n; i++ {
 				if err = deepMerge(dst.Field(i), src.Field(i), visited, depth+1, config); err != nil {
 					return
 				}
 			}
 		} else {
-			if dst.CanSet() && (!isEmptyValue(src) || overwriteWithEmptySrc) && (overwrite || isEmptyValue(dst)) {
+			if (isReflectNil(dst) || overwrite) && (!isEmptyValue(src) || overwriteWithEmptySrc) {
 				dst.Set(src)
 			}
 		}
@@ -89,6 +103,14 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 		if dst.IsNil() && !src.IsNil() {
 			dst.Set(reflect.MakeMap(dst.Type()))
 		}
+
+		if src.Kind() != reflect.Map {
+			if overwrite {
+				dst.Set(src)
+			}
+			return
+		}
+
 		for _, key := range src.MapKeys() {
 			srcElement := src.MapIndex(key)
 			if !srcElement.IsValid() {
@@ -98,6 +120,9 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 			switch srcElement.Kind() {
 			case reflect.Chan, reflect.Func, reflect.Map, reflect.Interface, reflect.Slice:
 				if srcElement.IsNil() {
+					if overwrite {
+						dst.SetMapIndex(key, srcElement)
+					}
 					continue
 				}
 				fallthrough
@@ -132,7 +157,7 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 						dstSlice = reflect.ValueOf(dstElement.Interface())
 					}
 
-					if (!isEmptyValue(src) || overwriteWithEmptySrc || overwriteSliceWithEmptySrc) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice {
+					if (!isEmptyValue(src) || overwriteWithEmptySrc || overwriteSliceWithEmptySrc) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice && !sliceDeepCopy {
 						if typeCheck && srcSlice.Type() != dstSlice.Type() {
 							return fmt.Errorf("cannot override two slices with different type (%s, %s)", srcSlice.Type(), dstSlice.Type())
 						}
@@ -142,6 +167,24 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 							return fmt.Errorf("cannot append two slices with different type (%s, %s)", srcSlice.Type(), dstSlice.Type())
 						}
 						dstSlice = reflect.AppendSlice(dstSlice, srcSlice)
+					} else if sliceDeepCopy {
+						i := 0
+						for ; i < srcSlice.Len() && i < dstSlice.Len(); i++ {
+							srcElement := srcSlice.Index(i)
+							dstElement := dstSlice.Index(i)
+
+							if srcElement.CanInterface() {
+								srcElement = reflect.ValueOf(srcElement.Interface())
+							}
+							if dstElement.CanInterface() {
+								dstElement = reflect.ValueOf(dstElement.Interface())
+							}
+
+							if err = deepMerge(dstElement, srcElement, visited, depth+1, config); err != nil {
+								return
+							}
+						}
+
 					}
 					dst.SetMapIndex(key, dstSlice)
 				}
@@ -161,26 +204,35 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 		if !dst.CanSet() {
 			break
 		}
-		if (!isEmptyValue(src) || overwriteWithEmptySrc || overwriteSliceWithEmptySrc) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice {
+		if (!isEmptyValue(src) || overwriteWithEmptySrc || overwriteSliceWithEmptySrc) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice && !sliceDeepCopy {
 			dst.Set(src)
 		} else if config.AppendSlice {
 			if src.Type() != dst.Type() {
 				return fmt.Errorf("cannot append two slice with different type (%s, %s)", src.Type(), dst.Type())
 			}
 			dst.Set(reflect.AppendSlice(dst, src))
+		} else if sliceDeepCopy {
+			for i := 0; i < src.Len() && i < dst.Len(); i++ {
+				srcElement := src.Index(i)
+				dstElement := dst.Index(i)
+				if srcElement.CanInterface() {
+					srcElement = reflect.ValueOf(srcElement.Interface())
+				}
+				if dstElement.CanInterface() {
+					dstElement = reflect.ValueOf(dstElement.Interface())
+				}
+
+				if err = deepMerge(dstElement, srcElement, visited, depth+1, config); err != nil {
+					return
+				}
+			}
 		}
 	case reflect.Ptr:
 		fallthrough
 	case reflect.Interface:
-		if src.IsNil() {
-			break
-		}
-
-		if dst.Kind() != reflect.Ptr && src.Type().AssignableTo(dst.Type()) {
-			if dst.IsNil() || overwrite {
-				if dst.CanSet() && (overwrite || isEmptyValue(dst)) {
-					dst.Set(src)
-				}
+		if isReflectNil(src) {
+			if overwriteWithEmptySrc && dst.CanSet() && src.Type().AssignableTo(dst.Type()) {
+				dst.Set(src)
 			}
 			break
 		}
@@ -203,16 +255,33 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 			}
 			break
 		}
+
 		if dst.IsNil() || overwrite {
 			if dst.CanSet() && (overwrite || isEmptyValue(dst)) {
 				dst.Set(src)
 			}
-		} else if err = deepMerge(dst.Elem(), src.Elem(), visited, depth+1, config); err != nil {
-			return
+			break
+		}
+
+		if dst.Elem().Kind() == src.Elem().Kind() {
+			if err = deepMerge(dst.Elem(), src.Elem(), visited, depth+1, config); err != nil {
+				return
+			}
+			break
 		}
 	default:
-		if dst.CanSet() && (!isEmptyValue(src) || overwriteWithEmptySrc) && (overwrite || isEmptyValue(dst)) {
-			dst.Set(src)
+		mustSet := (isEmptyValue(dst) || overwrite) && (!isEmptyValue(src) || overwriteWithEmptySrc)
+		v := fmt.Sprintf("%v", src)
+		if v == "TestIssue106" {
+			fmt.Println(mustSet)
+			fmt.Println(dst.CanSet())
+		}
+		if mustSet {
+			if dst.CanSet() {
+				dst.Set(src)
+			} else {
+				dst = src
+			}
 		}
 	}
 
@@ -246,7 +315,13 @@ func WithOverride(config *Config) {
 	config.Overwrite = true
 }
 
-// WithOverride will make merge override empty dst slice with empty src slice.
+// WithOverwriteWithEmptyValue will make merge override non empty dst attributes with empty src attributes values.
+func WithOverwriteWithEmptyValue(config *Config) {
+	config.Overwrite = true
+	config.overwriteWithEmptyValue = true
+}
+
+// WithOverrideEmptySlice will make merge override empty dst slice with empty src slice.
 func WithOverrideEmptySlice(config *Config) {
 	config.overwriteSliceWithEmptyValue = true
 }
@@ -261,7 +336,16 @@ func WithTypeCheck(config *Config) {
 	config.TypeCheck = true
 }
 
+// WithSliceDeepCopy will merge slice element one by one with Overwrite flag.
+func WithSliceDeepCopy(config *Config) {
+	config.sliceDeepCopy = true
+	config.Overwrite = true
+}
+
 func merge(dst, src interface{}, opts ...func(*Config)) error {
+	if dst != nil && reflect.ValueOf(dst).Kind() != reflect.Ptr {
+		return ErrNonPointerAgument
+	}
 	var (
 		vDst, vSrc reflect.Value
 		err        error
@@ -280,4 +364,17 @@ func merge(dst, src interface{}, opts ...func(*Config)) error {
 		return ErrDifferentArgumentsTypes
 	}
 	return deepMerge(vDst, vSrc, make(map[uintptr]*visit), 0, config)
+}
+
+// IsReflectNil is the reflect value provided nil
+func isReflectNil(v reflect.Value) bool {
+	k := v.Kind()
+	switch k {
+	case reflect.Interface, reflect.Slice, reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr:
+		// Both interface and slice are nil if first word is 0.
+		// Both are always bigger than a word; assume flagIndir.
+		return v.IsNil()
+	default:
+		return false
+	}
 }

--- a/vendor/github.com/imdario/mergo/mergo.go
+++ b/vendor/github.com/imdario/mergo/mergo.go
@@ -20,6 +20,7 @@ var (
 	ErrNotSupported                = errors.New("only structs and maps are supported")
 	ErrExpectedMapAsDestination    = errors.New("dst was expected to be a map")
 	ErrExpectedStructAsDestination = errors.New("dst was expected to be a struct")
+	ErrNonPointerAgument           = errors.New("dst must be a pointer")
 )
 
 // During deepMerge, must keep track of checks that are
@@ -74,24 +75,4 @@ func resolveValues(dst, src interface{}) (vDst, vSrc reflect.Value, err error) {
 		vSrc = vSrc.Elem()
 	}
 	return
-}
-
-// Traverses recursively both values, assigning src's fields values to dst.
-// The map argument tracks comparisons that have already been seen, which allows
-// short circuiting on recursive types.
-func deeper(dst, src reflect.Value, visited map[uintptr]*visit, depth int) (err error) {
-	if dst.CanAddr() {
-		addr := dst.UnsafeAddr()
-		h := 17 * addr
-		seen := visited[h]
-		typ := dst.Type()
-		for p := seen; p != nil; p = p.next {
-			if p.ptr == addr && p.typ == typ {
-				return nil
-			}
-		}
-		// Remember, remember...
-		visited[h] = &visit{addr, typ, seen}
-	}
-	return // TODO refactor
 }

--- a/vendor/google.golang.org/appengine/.travis.yml
+++ b/vendor/google.golang.org/appengine/.travis.yml
@@ -10,8 +10,6 @@ script:
 
 matrix:
   include:
-    - go: 1.8.x
-      env: GOAPP=true
     - go: 1.9.x
       env: GOAPP=true
     - go: 1.10.x

--- a/vendor/google.golang.org/appengine/internal/api.go
+++ b/vendor/google.golang.org/appengine/internal/api.go
@@ -58,8 +58,11 @@ var (
 
 	apiHTTPClient = &http.Client{
 		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			Dial:  limitDial,
+			Proxy:               http.ProxyFromEnvironment,
+			Dial:                limitDial,
+			MaxIdleConns:        1000,
+			MaxIdleConnsPerHost: 10000,
+			IdleConnTimeout:     90 * time.Second,
 		},
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -48,7 +48,8 @@ github.com/googleapis/gnostic/jsonschema
 github.com/googleapis/gnostic/openapiv2
 # github.com/huandu/xstrings v1.3.1
 github.com/huandu/xstrings
-# github.com/imdario/mergo v0.3.8
+# github.com/imdario/mergo v0.3.10
+## explicit
 github.com/imdario/mergo
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
@@ -283,7 +284,8 @@ golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
 # golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
 golang.org/x/time/rate
-# google.golang.org/appengine v1.6.5
+# google.golang.org/appengine v1.6.6
+## explicit
 google.golang.org/appengine
 google.golang.org/appengine/internal
 google.golang.org/appengine/internal/app_identity
@@ -380,6 +382,7 @@ gopkg.in/tomb.v1
 # gopkg.in/yaml.v2 v2.4.0
 gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+## explicit
 gopkg.in/yaml.v3
 # k8s.io/api v0.22.0 => k8s.io/api v0.22.0
 ## explicit


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

**Why is this PR required? What issue does it fix?**:
The integration tests for this repo fail due to incorrect checking criteria. This PR refines checking criteria and similar changes.

**What this PR does?**:
Changes summary:
1. Checks for BDC delete (in case of HOSTDEVICE tests) before moving on to next set of tests. This fixes an issue where a dangling BDC will claim the lone available BD and disrupt testing conditions.
2. Checks if NDM pods are running and a single BD with-no-filesystem is present before creating local-device volumes.
3. Checks for BD cleanup (in case of HOSTDEVICE tests) before moving on to next set of tests. This fixes an issue introduced by the above check (point no. 2). BD's which were not cleaned up generate a false negative when checking for the availability of 1 single no-filesystem BD.
                i. Adds utility methods for listing and filtering corev1.Events.
4.  If NDM components are present, the loop device created for XFS Quota tests is added to the NDM config path-filter's exclude list. This avoids detecting the loop device as a usable BD with NDM's ChangeDetection feature (in case /dev/loop devices are removed from exclude list).
                i. Adds utility methods for NDM Config.
5. The XFS Quota tests require 'sudo' to create and delete loop devices and other privileged operations (mkfs, mount). The sudo password prompt is issued 2 times during the test, once during BeforeSuite() and once during AfterSuite(). This is inconvenient. Added sudo as a prerequisite for the test suite.
                i. Updates tests/README.md and Makefile with sudo enabled command.
6. The XFS Quota tests assumes the directory used for HOSTPATH LOCAL PV tests to have a non-XFS filesystem. This invalidates the tests results. Made changes so that the loop device is formatted with ext4 filesystem and mounted.
                i. Adds utility function to run wipefs.
                ii. Adds mkfs option for ext4 filesystem
                iii. Adds mount option for ext4 filesystem (with Prjquota)
7. Mounts ext4 filesystem for NON-XFS FILESYSTEM xfs quota test with Prjquota to validate that non-xfs quota is not supported.
8. Modify [-ve] tests for HOSTDEVICE and XFS QUOTA Pod-count check criteria to check for non-negative result, instead of positive result.
9. Changes to directory structure used for XFS QUOTA tests -- moved disk image directory to primary integration test directory.
                i. Directory names are now generated to not stuff tests files with stale/existing test files.
10. Moved BuildPod() and BuildPersistentVolumeClaim() methods (used in XFS QUOTA tests) from the main test file to operations.go file.
11. Removed unused test artefacts which were left behind after the tests were copied over from openebs/maya.
12. Made changes to GitHub Actions CI to accommodate test prerequisites.

**Does this PR require any upgrade changes?**:
No.