### PR TITLE
chore(doc): fix syntax error in sample StorageClass for NodeAffinityLabels

### DIFF
--- a/docs/tutorials/hostpath/nodeaffinitylabels.md
+++ b/docs/tutorials/hostpath/nodeaffinitylabels.md
@@ -16,7 +16,7 @@ metadata:
     openebs.io/cas-type: local
     cas.openebs.io/config: |
       - name: StorageType
-      - value: "hostpath"
+        value: "hostpath"
       - name: NodeAffinityLabels
         list:
           - "openebs.io/custom-node-unique-id"


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

**Why is this PR required? What issue does it fix?**:
The sample StorageClass in the doc page for NodeAffinityLabels config key, has a typo.

**What this PR does?**:
Fixes the typo. Removes the '-' character and replaces it with a whitespace character.