### PR TITLE
feat(hostpath): enforce quotas for hostpath with an ext4 filesystem

### DIFF
--- a/cmd/provisioner-localpv/app/config.go
+++ b/cmd/provisioner-localpv/app/config.go
@@ -117,9 +117,19 @@ const (
 	//      data:
 	//        softLimitGrace: "80%"
 	//        hardLimitGrace: "85%"
-	KeyXFSQuota          = "XFSQuota"
-	KeyXfsQuotaSoftLimit = "softLimitGrace"
-	KeyXfsQuotaHardLimit = "hardLimitGrace"
+	KeyXFSQuota = "XFSQuota"
+
+	//KeyEXT4Quota enables/sets parameters for EXT4 Quota.
+	// Example StorageClass snippet:
+	//    - name: EXT4Quota
+	//      enabled: true
+	//      data:
+	//        softLimitGrace: "80%"
+	//        hardLimitGrace: "85%"
+	KeyEXT4Quota = "EXT4Quota"
+
+	KeyQuotaSoftLimit = "softLimitGrace"
+	KeyQuotaHardLimit = "hardLimitGrace"
 )
 
 const (
@@ -309,6 +319,23 @@ func (c *VolumeConfig) IsXfsQuotaEnabled() bool {
 	}
 
 	return enableXfsQuotaBool
+}
+
+func (c *VolumeConfig) IsExt4QuotaEnabled() bool {
+	ext4QuotaEnabled := c.getEnabled(KeyEXT4Quota)
+	ext4QuotaEnabled = strings.TrimSpace(ext4QuotaEnabled)
+
+	enableExt4QuotaBool, err := strconv.ParseBool(ext4QuotaEnabled)
+	//Default case
+	// this means that we have hit either of the two cases below:
+	//     i. The value was something other than a straightforward
+	//        true or false
+	//    ii. The value was empty
+	if err != nil {
+		return false
+	}
+
+	return enableExt4QuotaBool
 }
 
 //getValue is a utility function to extract the value

--- a/pkg/kubernetes/api/storage/v1/storageclass/utils.go
+++ b/pkg/kubernetes/api/storage/v1/storageclass/utils.go
@@ -76,7 +76,12 @@ func isCompatibleWithHostpath(s *storagev1.StorageClass) bool {
 			case "NodeAffinityLabel":
 				continue
 			case "XFSQuota":
-				if !isValidXfsQuotaData(config.Data) {
+				if !isValidQuotaData(config.Data) {
+					return false
+				}
+				continue
+			case "EXT4Quota":
+				if !isValidQuotaData(config.Data) {
 					return false
 				}
 				continue
@@ -93,11 +98,11 @@ func isCompatibleWithHostpath(s *storagev1.StorageClass) bool {
 	return true
 }
 
-func isValidXfsQuotaData(data map[string]string) bool {
+func isValidQuotaData(data map[string]string) bool {
 	if data == nil {
 		return true
 	}
-	if softLimit, ok := data[KeyXfsQuotaSoftLimit]; ok {
+	if softLimit, ok := data[KeyQuotaSoftLimit]; ok {
 		//Allows values of the following formats:
 		// 123.456%, 123%, 123.%, .45%
 		//Does not allow:
@@ -106,7 +111,7 @@ func isValidXfsQuotaData(data map[string]string) bool {
 			return false
 		}
 	}
-	if hardLimit, ok := data[KeyXfsQuotaHardLimit]; ok {
+	if hardLimit, ok := data[KeyQuotaHardLimit]; ok {
 		//Allows values of the following formats:
 		// 123.456%, 123%, 123.%, .45%
 		//Does not allow:
@@ -119,7 +124,7 @@ func isValidXfsQuotaData(data map[string]string) bool {
 	return true
 }
 
-func isCompatibleWithXfsQuota(s *storagev1.StorageClass) bool {
+func isCompatibleWithQuota(s *storagev1.StorageClass) bool {
 	if !isCompatibleWithLocalPVcasType(s) {
 		return false
 	}
@@ -187,7 +192,12 @@ func isCompatibleWithNodeAffinityLabel(s *storagev1.StorageClass) bool {
 				}
 				continue
 			case "XFSQuota":
-				if !isValidXfsQuotaData(config.Data) {
+				if !isValidQuotaData(config.Data) {
+					return false
+				}
+				continue
+			case "EXT4Quota":
+				if !isValidQuotaData(config.Data) {
 					return false
 				}
 				continue

--- a/tests/disk/disk.go
+++ b/tests/disk/disk.go
@@ -32,9 +32,9 @@ import (
 
 const (
 	// DiskImageSize is the default file size(1GB) used while creating backing image
-	DiskImageSize               = 1073741824
-	DiskImageNamePrefix         = "openebs-disk"
-	XfsQuotaDiskImageNamePrefix = DiskImageNamePrefix + "-xfs_quota"
+	DiskImageSize            = 1073741824
+	DiskImageNamePrefix      = "openebs-disk"
+	QuotaDiskImageNamePrefix = DiskImageNamePrefix + "-quota"
 )
 
 // Disk has the attributes of a virtual disk which is emulated for integration
@@ -65,7 +65,7 @@ func NewDisk(size int64) Disk {
 }
 
 func (disk *Disk) createDiskImage(imgDir string) error {
-	f, err := ioutil.TempFile(imgDir, XfsQuotaDiskImageNamePrefix+"-*.img")
+	f, err := ioutil.TempFile(imgDir, QuotaDiskImageNamePrefix+"-*.img")
 	if err != nil {
 		return fmt.Errorf("error creating disk image. Error : %v", err)
 	}
@@ -138,6 +138,8 @@ func RunCommand(cmd string) ([]byte, error) {
 func (disk *Disk) CreateFilesystem(fstype string) error {
 	var mkfsCommand string
 	switch fstype {
+	case "minix":
+		mkfsCommand = "mkfs.minix " + disk.DiskPath
 	case "ext4":
 		mkfsCommand = "mkfs.ext4 -O quota -E quotatype=prjquota " + disk.DiskPath
 	case "xfs":
@@ -243,7 +245,7 @@ func (disk *Disk) DetachAndDeleteDisk() error {
 	return nil
 }
 
-// PrepareDisk prepares the setup necessary for testing xfs hostpath quota
+// PrepareDisk prepares the setup necessary for testing xfs/ext4 hostpath quota
 func PrepareDisk(imgDir, hostPath string) (Disk, error) {
 	physicalDisk := NewDisk(DiskImageSize)
 

--- a/tests/hostpath_quota_test.go
+++ b/tests/hostpath_quota_test.go
@@ -29,7 +29,7 @@ import (
 	sc "github.com/openebs/dynamic-localpv-provisioner/pkg/kubernetes/api/storage/v1/storageclass"
 )
 
-var _ = Describe("TEST HOSTPATH XFS QUOTA LOCAL PV WITH NON-XFS FILESYSTEM", func() {
+var _ = Describe("TEST HOSTPATH XFS QUOTA LOCAL PV WITH UNSUPPORTED FILESYSTEM", func() {
 	var (
 		pvcObj      *corev1.PersistentVolumeClaim
 		scObj       *storagev1.StorageClass
@@ -39,7 +39,7 @@ var _ = Describe("TEST HOSTPATH XFS QUOTA LOCAL PV WITH NON-XFS FILESYSTEM", fun
 		label       = "demo=hostpath-pod"
 		createdPvc  *corev1.PersistentVolumeClaim
 
-		pvcName       = "pvc-hp"
+		pvcName       = "pvc-hp-xfs"
 		scNamePrefix  = "sc-hp-xfs"
 		scName        string
 		podObj        *corev1.Pod
@@ -82,7 +82,7 @@ var _ = Describe("TEST HOSTPATH XFS QUOTA LOCAL PV WITH NON-XFS FILESYSTEM", fun
 
 	When("pvc with storageclass "+scName+" is created", func() {
 		It("should create a pvc", func() {
-			By("Writing ext4 filesystem into the loop device")
+			By("Writing minix filesystem into the loop device")
 			//umount
 			errs := physicalDisk.Unmount()
 			Expect(errs).To(BeEmpty(), "when unmounting loop device")
@@ -90,7 +90,7 @@ var _ = Describe("TEST HOSTPATH XFS QUOTA LOCAL PV WITH NON-XFS FILESYSTEM", fun
 			err := physicalDisk.Wipefs()
 			Expect(err).To(BeNil(), "when wiping filesystem from loop device")
 			//mkfs
-			err = physicalDisk.CreateFilesystem("ext4")
+			err = physicalDisk.CreateFilesystem("minix")
 			Expect(err).To(BeNil(), "when writing filesystem to loop device")
 			//mount
 			err = physicalDisk.PrjquotaMount(loopHostpathDir)
@@ -217,7 +217,7 @@ var _ = Describe("TEST HOSTPATH XFS QUOTA LOCAL PV WITH XFS FILESYSTEM", func() 
 		podName       = "busybox-hostpath"
 		label         = "demo=hostpath-pod"
 		createdPod    *corev1.Pod
-		pvcName       = "pvc-hp"
+		pvcName       = "pvc-hp-xfs"
 		scNamePrefix  = "sc-hp-xfs"
 		scName        string
 		podObj        *corev1.Pod
@@ -398,6 +398,385 @@ var _ = Describe("TEST HOSTPATH XFS QUOTA LOCAL PV WITH XFS FILESYSTEM", func() 
 			)
 
 			By("removing the xfs filesystem")
+			//umount
+			errs := physicalDisk.Unmount()
+			Expect(errs).To(BeEmpty(), "when unmounting loop device")
+			//wipefs
+			err := physicalDisk.Wipefs()
+			Expect(err).To(BeNil(), "when wiping filesystem from loop device")
+		})
+	})
+})
+
+var _ = Describe("TEST HOSTPATH EXT4 QUOTA LOCAL PV WITH UNSUPPORTED FILESYSTEM", func() {
+	var (
+		pvcObj      *corev1.PersistentVolumeClaim
+		scObj       *storagev1.StorageClass
+		accessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
+		capacity    = "5M"
+		podName     = "busybox-hostpath"
+		label       = "demo=hostpath-pod"
+		createdPvc  *corev1.PersistentVolumeClaim
+
+		pvcName       = "pvc-hp-ext4"
+		scNamePrefix  = "sc-hp-ext4"
+		scName        string
+		podObj        *corev1.Pod
+		labelselector = map[string]string{
+			"demo": "hostpath-pod",
+		}
+	)
+
+	When("StorageClass with valid ext4 quota parameters is created", func() {
+		It("should create a StorageClass", func() {
+			By("building a StorageClass")
+			scObj, err = sc.NewStorageClass(
+				sc.WithGenerateName(scNamePrefix),
+				sc.WithLabels(map[string]string{
+					"openebs.io/test-sc": "true",
+				}),
+				sc.WithLocalPV(),
+				sc.WithHostpath(loopHostpathDir),
+				sc.WithExt4Quota("20%", "50%"),
+				sc.WithVolumeBindingMode("WaitForFirstConsumer"),
+				sc.WithReclaimPolicy("Delete"),
+			)
+			Expect(err).To(
+				BeNil(),
+				"while building StorageClass with name prefix {%s}",
+				scNamePrefix,
+			)
+
+			By("creating StorageClass API resource")
+			scObj, err = ops.SCClient.Create(context.TODO(), scObj)
+			Expect(err).To(
+				BeNil(),
+				"while creating StorageClass with name prefix {%s}",
+				scNamePrefix,
+			)
+			scName = scObj.ObjectMeta.Name
+			Expect(scName).NotTo(BeEmpty(), "SC name should not be empty")
+		})
+	})
+
+	When("pvc with storageclass "+scName+" is created", func() {
+		It("should create a pvc", func() {
+			By("Writing minix filesystem into the loop device")
+			//umount
+			errs := physicalDisk.Unmount()
+			Expect(errs).To(BeEmpty(), "when unmounting loop device")
+			//wipefs
+			err := physicalDisk.Wipefs()
+			Expect(err).To(BeNil(), "when wiping filesystem from loop device")
+			//mkfs
+			err = physicalDisk.CreateFilesystem("minix")
+			Expect(err).To(BeNil(), "when writing filesystem to loop device")
+			//mount
+			err = physicalDisk.PrjquotaMount(loopHostpathDir)
+			Expect(err).To(
+				BeNil(),
+				"when mounting loop device filesystem to mountpoint",
+			)
+
+			By("building a PVC with StorageClass " + scName)
+			Expect(scName).NotTo(BeEmpty(), "SC name should not be empty")
+			pvcObj, err = BuildPersistentVolumeClaim(namespaceObj.Name, pvcName, scName, capacity, accessModes)
+			Expect(err).ShouldNot(
+				HaveOccurred(),
+				"while building PVC {%s} in namespace {%s}",
+				pvcName,
+				namespaceObj.Name,
+			)
+
+			By("creating above PVC with StorageClass " + scName)
+			createdPvc, err = ops.PVCClient.WithNamespace(namespaceObj.Name).Create(context.TODO(), pvcObj)
+			Expect(err).To(
+				BeNil(),
+				"while creating PVC {%s} in namespace {%s}",
+				pvcName,
+				namespaceObj.Name,
+			)
+		})
+	})
+
+	When("pod is created with pvc "+pvcName, func() {
+		It("should be in pending state and so do pvc", func() {
+			By("building a pod with busybox image")
+			podObj, err = BuildPod(namespaceObj.Name, podName, pvcName, labelselector)
+			Expect(err).ShouldNot(
+				HaveOccurred(),
+				"while building pod {%s} in namespace {%s}",
+				podName,
+				namespaceObj.Name,
+			)
+
+			By("creating above pod with busybox image")
+			_, err := ops.PodClient.WithNamespace(namespaceObj.Name).
+				Create(context.TODO(), podObj)
+			Expect(err).To(
+				BeNil(),
+				"while creating pod {%s} in namespace {%s}",
+				podName,
+				namespaceObj.Name,
+			)
+
+			By("verifying pod status as pending")
+			//Giving the check till timeout to try to see if the Status changes to Running
+			podPhase := ops.CheckPodStatusEventually(namespaceObj.Name, podName, corev1.PodRunning)
+			Expect(podPhase).To(Equal(corev1.PodPending), "while verifying pod pending status")
+
+			By("verifying the pvc phase as pending")
+			Expect(createdPvc.Status.Phase).To(Equal(corev1.ClaimPending), "while verifying the pvc pending state")
+		})
+	})
+
+	When("Pod consuming pvc "+pvcName+" is deleted", func() {
+		It("should delete the pod", func() {
+			By("deleting above pod")
+			err = ops.PodClient.WithNamespace(namespaceObj.Name).Delete(context.TODO(), podName, &metav1.DeleteOptions{})
+			Expect(err).To(
+				BeNil(),
+				"while deleting pod {%s} in namespace {%s}",
+				podName,
+				namespaceObj.Name,
+			)
+
+			By("verifying pod count as 0")
+			podCount := ops.GetPodCountEventually(namespaceObj.Name, label, nil, 0)
+			Expect(podCount).To(Equal(0), "while verifying pod count")
+		})
+	})
+
+	When("pvc with storageclass "+scName+" is deleted", func() {
+		It("should delete the pvc", func() {
+			By("verifying that the VolumeName is empty for the PVC")
+			pvName := ops.GetPVNameFromPVCName(namespaceObj.Name, pvcName)
+			Expect(pvName).To(
+				BeEmpty(),
+				"while getting Spec.VolumeName from PVC {%s} in namespace {%s}",
+				pvcName,
+				namespaceObj.Name,
+			)
+
+			By("deleting above PVC")
+			err = ops.PVCClient.Delete(context.TODO(), pvcName, &metav1.DeleteOptions{})
+			Expect(err).To(
+				BeNil(),
+				"while deleting pvc {%s} in namespace {%s}",
+				pvcName,
+				namespaceObj.Name,
+			)
+
+			By("verifying PVC is deleted")
+			status := ops.IsPVCDeletedEventually(pvcName, namespaceObj.Name)
+			Expect(status).To(
+				BeTrue(),
+				"when checking status of deleted PVC {%s}",
+				pvcName,
+			)
+
+			By("removing the xfs filesystem")
+			//umount
+			errs := physicalDisk.Unmount()
+			Expect(errs).To(BeEmpty(), "when unmounting loop device")
+			//wipefs
+			err := physicalDisk.Wipefs()
+			Expect(err).To(BeNil(), "when wiping filesystem from loop device")
+		})
+	})
+})
+
+var _ = Describe("TEST HOSTPATH EXT4 QUOTA LOCAL PV WITH EXT4 FILESYSTEM", func() {
+	var (
+		pvcObj        *corev1.PersistentVolumeClaim
+		scObj         *storagev1.StorageClass
+		accessModes   = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
+		capacityInMib = "5"
+		capacity      = capacityInMib + "M"
+		podName       = "busybox-hostpath"
+		label         = "demo=hostpath-pod"
+		createdPod    *corev1.Pod
+		pvcName       = "pvc-hp-ext4"
+		scNamePrefix  = "sc-hp-ext4"
+		scName        string
+		podObj        *corev1.Pod
+		labelselector = map[string]string{
+			"demo": "hostpath-pod",
+		}
+	)
+
+	When("StorageClass with valid ext4 quota parameters is created", func() {
+		It("should create a StorageClass", func() {
+			By("building a StorageClass")
+			scObj, err = sc.NewStorageClass(
+				sc.WithGenerateName(scNamePrefix),
+				sc.WithLabels(map[string]string{
+					"openebs.io/test-sc": "true",
+				}),
+				sc.WithLocalPV(),
+				sc.WithHostpath(loopHostpathDir),
+				sc.WithExt4Quota("", ""),
+				sc.WithVolumeBindingMode("WaitForFirstConsumer"),
+				sc.WithReclaimPolicy("Delete"),
+			)
+			Expect(err).To(
+				BeNil(),
+				"while building StorageClass with name prefix {%s}",
+				scNamePrefix,
+			)
+
+			By("creating StorageClass API resource")
+			scObj, err = ops.SCClient.Create(context.TODO(), scObj)
+			Expect(err).To(
+				BeNil(),
+				"while creating StorageClass with name prefix {%s}",
+				scNamePrefix,
+			)
+			scName = scObj.ObjectMeta.Name
+			Expect(scName).NotTo(BeEmpty(), "SC name should not be empty")
+		})
+	})
+
+	When("pvc with storageclass "+scName+" is created", func() {
+		It("should create a pvc", func() {
+			By("Writing ext4 filesystem into the loop device")
+			//umount
+			errs := physicalDisk.Unmount()
+			Expect(errs).To(BeEmpty(), "when unmounting loop device")
+			//wipefs
+			err := physicalDisk.Wipefs()
+			Expect(err).To(BeNil(), "when wiping filesystem from loop device")
+			//mkfs
+			err = physicalDisk.CreateFilesystem("ext4")
+			Expect(err).To(BeNil(), "when writing filesystem to loop device")
+			//mount
+			err = physicalDisk.PrjquotaMount(loopHostpathDir)
+			Expect(err).To(
+				BeNil(),
+				"when mounting loop device filesystem to mountpoint",
+			)
+
+			By("building a PVC with StorageClass " + scName)
+			Expect(scName).NotTo(BeEmpty(), "SC name should not be empty")
+			pvcObj, err = BuildPersistentVolumeClaim(namespaceObj.Name, pvcName, scName, capacity, accessModes)
+			Expect(err).ShouldNot(
+				HaveOccurred(),
+				"while building PVC {%s} in namespace {%s}",
+				pvcName,
+				namespaceObj.Name,
+			)
+
+			By("creating above PVC with StorageClass " + scName)
+			_, err = ops.PVCClient.WithNamespace(namespaceObj.Name).Create(context.TODO(), pvcObj)
+			Expect(err).To(
+				BeNil(),
+				"while creating PVC {%s} in namespace {%s}",
+				pvcName,
+				namespaceObj.Name,
+			)
+		})
+	})
+
+	When("pod is created with pvc "+pvcName, func() {
+		It("should be up and running", func() {
+			By("building a pod with busybox image")
+			podObj, err = BuildPod(namespaceObj.Name, podName, pvcName, labelselector)
+			Expect(err).ShouldNot(
+				HaveOccurred(),
+				"while building pod {%s} in namespace {%s}",
+				podName,
+				namespaceObj.Name,
+			)
+
+			By("creating above pod with busybox image")
+			createdPod, err = ops.PodClient.WithNamespace(namespaceObj.Name).
+				Create(context.TODO(), podObj)
+			Expect(err).To(
+				BeNil(),
+				"while creating pod {%s} in namespace {%s}",
+				podName,
+				namespaceObj.Name,
+			)
+
+			By("verifying pod count as 1")
+			podCount := ops.GetPodRunningCountEventually(namespaceObj.Name, label, 1)
+			Expect(podCount).To(Equal(1), "while verifying pod count")
+		})
+	})
+
+	When("writing data more than quota limit into the hostpath volume", func() {
+		It("should not be able to write more than the enforced limit", func() {
+			By("Verifying the quota applied on the volume works")
+			execOption := NewOptions()
+			// The command formed below is attempting to create a file named “test.txt” inside the attached volume,
+			// its size increasing 1M in each iteration of the loop should show us the quota in action.
+			option := execOption.WithPodName(createdPod.Name).
+				WithContainer("busybox").
+				WithNamespace(namespaceObj.Name).
+				WithCommand([]string{"/bin/sh", "-c", "dd if=/dev/zero of=/mnt/store1/test.txt bs=1M count=10 2>&1 || du -sm /mnt/store1 | cut -f -1 | tr -d '\n' 1>&2"}...)
+			stdOut, stdErr, err := ops.ExecPod(option)
+			fmt.Printf("When running command to test enforced quota. stdOut: {%s}, stderr: {%s}, error: {%v}", stdOut, stdErr, err)
+			Expect(err).To(BeNil(), "while exec'ing into the pod and running command(s)")
+			Expect(stdOut).NotTo(BeEmpty(), "trying to write till the quota limit should be allowed")
+			Expect(stdErr).To(Equal(capacityInMib), "trying to write beyond the quota limit should not be allowed")
+		})
+	})
+
+	When("Pod consuming pvc "+pvcName+" is deleted", func() {
+		It("should delete the pod", func() {
+			By("deleting above pod")
+			err = ops.PodClient.WithNamespace(namespaceObj.Name).Delete(context.TODO(), podName, &metav1.DeleteOptions{})
+			Expect(err).To(
+				BeNil(),
+				"while deleting pod {%s} in namespace {%s}",
+				podName,
+				namespaceObj.Name,
+			)
+
+			By("verifying pod count as 0")
+			podCount := ops.GetPodCountEventually(namespaceObj.Name, label, nil, 0)
+			Expect(podCount).To(Equal(0), "while verifying pod count")
+		})
+	})
+
+	When("pvc with storageclass "+scName+" is deleted", func() {
+		It("should delete the pvc", func() {
+			By("getting the PV name from Bound PVC object spec")
+			pvName := ops.GetPVNameFromPVCName(namespaceObj.Name, pvcName)
+			Expect(pvName).ToNot(
+				BeEmpty(),
+				"while getting Spec.VolumeName from "+
+					"PVC {%s} in namespace {%s}",
+				pvcName,
+				namespaceObj.Name,
+			)
+
+			By("deleting above PVC")
+			err = ops.PVCClient.Delete(context.TODO(), pvcName, &metav1.DeleteOptions{})
+			Expect(err).To(
+				BeNil(),
+				"while deleting pvc {%s} in namespace {%s}",
+				pvcName,
+				namespaceObj.Name,
+			)
+
+			By("having the Provisioner delete the PV")
+			status := ops.IsPVDeletedEventually(pvName)
+			Expect(status).To(
+				BeTrue(),
+				"while waiting for the Provisioner to delete PV {%s}",
+				pvName,
+			)
+
+			By("verifying PVC is deleted")
+			status = ops.IsPVCDeletedEventually(pvcName, namespaceObj.Name)
+			Expect(status).To(
+				BeTrue(),
+				"when checking status of deleted PVC {%s}",
+				pvcName,
+			)
+
+			By("removing the ext4 filesystem")
 			//umount
 			errs := physicalDisk.Unmount()
 			Expect(errs).To(BeEmpty(), "when unmounting loop device")

--- a/tests/hostpath_quota_test.go
+++ b/tests/hostpath_quota_test.go
@@ -196,7 +196,7 @@ var _ = Describe("TEST HOSTPATH XFS QUOTA LOCAL PV WITH UNSUPPORTED FILESYSTEM",
 				pvcName,
 			)
 
-			By("removing the ext4 filesystem")
+			By("removing the minix filesystem")
 			//umount
 			errs := physicalDisk.Unmount()
 			Expect(errs).To(BeEmpty(), "when unmounting loop device")
@@ -575,7 +575,7 @@ var _ = Describe("TEST HOSTPATH EXT4 QUOTA LOCAL PV WITH UNSUPPORTED FILESYSTEM"
 				pvcName,
 			)
 
-			By("removing the xfs filesystem")
+			By("removing the minix filesystem")
 			//umount
 			errs := physicalDisk.Unmount()
 			Expect(errs).To(BeEmpty(), "when unmounting loop device")

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -100,7 +100,7 @@ var _ = BeforeSuite(func() {
 	loopHostpathDir = filepath.Join(hostpathDir, loopHostpathDirName)
 	loopDiskImgDir = filepath.Join(hostpathDir, loopDiskImgDirName)
 
-	By("preparing the loop device for hostpath XFS Quota tests")
+	By("preparing the loop device for hostpath Quota tests")
 	//Checking if NDM might be used for LOCAL HOSTDEVICE tests
 	ndmState = ops.IsNdmPrerequisiteMet(openebsNamespace, ndmLabelSelector, ndmOperatorLabelSelector)
 	physicalDisk, err = disk.PrepareDisk(loopDiskImgDir, loopHostpathDir)


### PR DESCRIPTION
Signed-off-by: Jacoby Hickerson jacoby.hickerson@outlook.com

**Why is this PR required? What issue does it fix?**:
Quotas have been implemented on xfs filesystems, this PR extends that to ext4 filesystems. 
This PR fixes issue: https://github.com/openebs/dynamic-localpv-provisioner/issues/136

**What this PR does?**:
This PR enforces quotas on the hostpath that is formatted with an ext4 filesystem.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
The setup, deployment and test instructions can be found here:
https://pastebin.com/PK6XVDkp

**Any additional information for your reviewer?** : 
This PR is a contribution to the xfs quota enforcement pr: https://github.com/openebs/dynamic-localpv-provisioner/pull/78


**Checklist:**
- [ ] Fixes #136
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 