### PR TITLE
chore(doc): use correct mount path in busy box startup command

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -233,7 +233,7 @@ spec:
   - command:
        - sh
        - -c
-       - 'date >> /mnt/openebs-csi/date.txt; hostname >> /mnt/openebs-csi/hostname.txt; sync; sleep 5; sync; tail -f /dev/null;'
+       - 'date >> /mnt/data/date.txt; hostname >> /mnt/data/hostname.txt; sync; sleep 5; sync; tail -f /dev/null;'
     image: busybox
     name: busybox
     volumeMounts:


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:

With incorrect path the Pod just outputs "directory not found"

**What this PR does?**:

Changes the path for the startup command to use the mounted PV instead