### PR TITLE
chore(doc): Improve documentation for Talos

### DIFF
--- a/docs/installation/platforms/talos.md
+++ b/docs/installation/platforms/talos.md
@@ -19,4 +19,19 @@ kubelet:
             - rw
 ```
 
-After adding the `extraMounts` are added, proceed with installation as described in [the quickstart](https://github.com/openebs/dynamic-localpv-provisioner/blob/develop/docs/quickstart.md).
+If you are using the default Talos security policy you will also have to add privileged security labels on the `openebs` namespace to allow it to use `hostPath` volumes. Eg:
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: openebs
+    labels:
+        pod-security.kubernetes.io/audit: privileged
+        pod-security.kubernetes.io/enforce: privileged
+        pod-security.kubernetes.io/warn: privileged
+```
+
+Caution: When using local storage on Talos, you must remember to pass the `--preserve` argument when running `talosctl upgrade` to avoid host paths getting wiped out during the upgrade (as noted in [Talos Local Storage documentation](https://www.talos.dev/v1.2/kubernetes-guides/configuration/replicated-local-storage-with-openebs-jiva/)).
+
+After adding the required configuration, proceed with installation as described in [the quickstart](https://github.com/openebs/dynamic-localpv-provisioner/blob/develop/docs/quickstart.md).


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:

Attempting to install the provisioner on Talos without adding privilege to the `openebs` namespace will cause errors since Talos security policy will prevent the provisioner from using `hostPath`

**What this PR does?**:

Adds documentation regarding the need for adding privilege as well as a note of caution that `--preserve` must be used when upgrading Talos to avoid wiping out volumes.

Note: I'm not an expert when it comes to Kubernetes security so feel free to propose a different approach for meeting the Talos security policy. In this PR I provided an example of YAML configuration that is confirmed to work for us using the current version of Talos.