### PR TITLE
feat: Add support to specify file permissions for pvc hostpaths

### DIFF
--- a/cmd/provisioner-localpv/app/config.go
+++ b/cmd/provisioner-localpv/app/config.go
@@ -142,12 +142,6 @@ const (
 	// This is the cas-template key for all file permission 'data' keys
 	KeyFilePermissions = "FilePermissions"
 
-	// FsUID defines the user owner of the shared directory
-	KeyFsUID = "UID"
-
-	// FsGID defines the group owner of the shared directory
-	KeyFsGID = "GID"
-
 	// FSMode defines the file permission mode of the shared directory
 	KeyFsMode = "mode"
 )
@@ -383,36 +377,6 @@ func (c *VolumeConfig) IsPermissionEnabled() bool {
 	}
 
 	return permissionEnabledQuotaBool
-}
-
-// GetFsGID fetches the group owner's ID from
-// PVC annotation, if specified
-// NOT YET USED
-func (c *VolumeConfig) GetFsGID() string {
-	if c.IsPermissionEnabled() {
-		configData := c.getData(KeyFilePermissions)
-		if configData != nil {
-			if val, p := configData[KeyFsGID]; p {
-				return strings.TrimSpace(val)
-			}
-		}
-	}
-	return ""
-}
-
-// GetFsGID fetches the user owner's ID from
-// PVC annotation, if specified
-// NOT YET USED
-func (c *VolumeConfig) GetFsUID() string {
-	if c.IsPermissionEnabled() {
-		configData := c.getData(KeyFilePermissions)
-		if configData != nil {
-			if val, p := configData[KeyFsUID]; p {
-				return strings.TrimSpace(val)
-			}
-		}
-	}
-	return ""
 }
 
 // GetFsMode fetches the file mode from PVC

--- a/cmd/provisioner-localpv/app/config.go
+++ b/cmd/provisioner-localpv/app/config.go
@@ -427,7 +427,7 @@ func (c *VolumeConfig) GetFsMode() string {
 		}
 	}
 	//Keep the original default mode
-	return "0777"
+	return ""
 }
 
 // getValue is a utility function to extract the value

--- a/cmd/provisioner-localpv/app/config.go
+++ b/cmd/provisioner-localpv/app/config.go
@@ -134,7 +134,6 @@ const (
 	// FilePermissions allows to define the default directory mode
 	// Exemple StorageClass snippet:
 	//    - name: FilePermissions
-	//      enabled: true
 	//      data:
 	//        UID: 1000
 	//        GID: 1000
@@ -362,32 +361,13 @@ func (c *VolumeConfig) IsExt4QuotaEnabled() bool {
 	return enableExt4QuotaBool
 }
 
-func (c *VolumeConfig) IsPermissionEnabled() bool {
-	permissionEnabled := c.getEnabled(KeyFilePermissions)
-	permissionEnabled = strings.TrimSpace(permissionEnabled)
-
-	permissionEnabledQuotaBool, err := strconv.ParseBool(permissionEnabled)
-	//Default case
-	// this means that we have hit either of the two cases below:
-	//     i. The value was something other than a straightforward
-	//        true or false
-	//    ii. The value was empty
-	if err != nil {
-		return false
-	}
-
-	return permissionEnabledQuotaBool
-}
-
 // GetFsMode fetches the file mode from PVC
 // or StorageClass annotation, if specified
 func (c *VolumeConfig) GetFsMode() string {
-	if c.IsPermissionEnabled() {
-		configData := c.getData(KeyFilePermissions)
-		if configData != nil {
-			if val, p := configData[KeyFsMode]; p {
-				return strings.TrimSpace(val)
-			}
+	configData := c.getData(KeyFilePermissions)
+	if configData != nil {
+		if val, p := configData[KeyFsMode]; p {
+			return strings.TrimSpace(val)
 		}
 	}
 	//Keep the original default mode

--- a/cmd/provisioner-localpv/app/config.go
+++ b/cmd/provisioner-localpv/app/config.go
@@ -197,7 +197,7 @@ func (p *Provisioner) GetVolumeConfig(ctx context.Context, pvName string, pvc *c
 	if len(strings.TrimSpace(pvcCASConfigStr)) != 0 {
 		pvcCASConfig, err := cast.UnMarshallToConfig(pvcCASConfigStr)
 		if err == nil {
-			pvConfig = cast.MergeConfig(pvcCASConfig, pvConfig)
+			pvConfig = cast.MergeConfig(pvConfig, pvcCASConfig)
 		} else {
 			return nil, errors.Wrapf(err, "failed to get config: invalid config {%v}"+
 				" in pvc {%v} in namespace {%v}",

--- a/cmd/provisioner-localpv/app/config_test.go
+++ b/cmd/provisioner-localpv/app/config_test.go
@@ -105,6 +105,43 @@ func TestDataConfigToMap(t *testing.T) {
 	}
 }
 
+func TestPermissionConfigToMap(t *testing.T) {
+	hostpathConfig := mconfig.Config{Name: "StorageType", Value: "hostpath"}
+	permissionConfig := mconfig.Config{Name: "FilePermissions", Enabled: "true",
+		Data: map[string]string{
+			"mode": "0750",
+		},
+	}
+
+	testCases := map[string]struct {
+		config        []mconfig.Config
+		expectedValue map[string]interface{}
+	}{
+		"nil 'Data' map": {
+			config: []mconfig.Config{hostpathConfig, permissionConfig},
+			expectedValue: map[string]interface{}{
+				"FilePermissions": map[string]string{
+					"mode": "0750",
+				},
+			},
+		},
+	}
+
+	for k, v := range testCases {
+		v := v
+		k := k
+		t.Run(k, func(t *testing.T) {
+			actualValue, err := dataConfigToMap(v.config)
+			if err != nil {
+				t.Errorf("expected error to be nil, but got %v", err)
+			}
+			if !reflect.DeepEqual(actualValue, v.expectedValue) {
+				t.Errorf("expected %v, but got %v", v.expectedValue, actualValue)
+			}
+		})
+	}
+}
+
 func Test_listConfigToMap(t *testing.T) {
 	tests := map[string]struct {
 		pvConfig      []mconfig.Config

--- a/cmd/provisioner-localpv/app/config_test.go
+++ b/cmd/provisioner-localpv/app/config_test.go
@@ -107,7 +107,7 @@ func TestDataConfigToMap(t *testing.T) {
 
 func TestPermissionConfigToMap(t *testing.T) {
 	hostpathConfig := mconfig.Config{Name: "StorageType", Value: "hostpath"}
-	permissionConfig := mconfig.Config{Name: "FilePermissions", Enabled: "true",
+	permissionConfig := mconfig.Config{Name: "FilePermissions",
 		Data: map[string]string{
 			"mode": "0750",
 		},

--- a/cmd/provisioner-localpv/app/provisioner_hostpath.go
+++ b/cmd/provisioner-localpv/app/provisioner_hostpath.go
@@ -77,7 +77,12 @@ func (p *Provisioner) ProvisionHostPath(ctx context.Context, opts pvController.P
 	klog.Infof("Creating volume %v at node with labels {%v}, path:%v,ImagePullSecrets:%v", name, nodeAffinityLabels, path, imagePullSecrets)
 
 	//Before using the path for local PV, make sure it is created.
-	initCmdsForPath := []string{"mkdir", "-m", volumeConfig.GetFsMode(), "-p"}
+        fsMode := volumeConfig.GetFsMode()
+        // Set default value if FilePermissions mode is not specified.
+        if len(fsMode) == 0 {
+                fsMode = "0777"
+        }
+	initCmdsForPath := []string{"mkdir", "-m", fsMode, "-p"}
 	podOpts := &HelperPodOptions{
 		cmdsForPath:        initCmdsForPath,
 		name:               name,

--- a/cmd/provisioner-localpv/app/provisioner_hostpath.go
+++ b/cmd/provisioner-localpv/app/provisioner_hostpath.go
@@ -77,7 +77,7 @@ func (p *Provisioner) ProvisionHostPath(ctx context.Context, opts pvController.P
 	klog.Infof("Creating volume %v at node with labels {%v}, path:%v,ImagePullSecrets:%v", name, nodeAffinityLabels, path, imagePullSecrets)
 
 	//Before using the path for local PV, make sure it is created.
-	initCmdsForPath := []string{"mkdir", "-m", "0777", "-p"}
+	initCmdsForPath := []string{"mkdir", "-m", volumeConfig.GetFsMode(), "-p"}
 	podOpts := &HelperPodOptions{
 		cmdsForPath:        initCmdsForPath,
 		name:               name,

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-A Kubernetes cluster with Kubernetes v1.16 or above. 
+A Kubernetes cluster with Kubernetes v1.16 or above.
 
 For more platform-specific installation instructions, [click here](./installation/platforms/).
 
@@ -13,12 +13,12 @@ Install OpenEBS Dynamic LocalPV Provisioner using the openebs helm chart. Sample
 #helm repo update
 helm install openebs openebs/openebs -n openebs --create-namespace
 ```
-	
+
 <details>
   <summary>Click here for configuration options.</summary>
 
-  1. Install OpenEBS Dynamic LocalPV Provisioner without NDM. 
-     
+  1. Install OpenEBS Dynamic LocalPV Provisioner without NDM.
+
      You may choose to exclude the NDM subchart from installation if...
      - you want to only use OpenEBS LocalPV Hostpath
      - you already have NDM installed. Check if NDM pods exist with the command `kubectl get pods -n openebs -l 'openebs.io/component-name in (ndm, ndm-operator)'`
@@ -35,7 +35,7 @@ helm install openebs openebs/openebs -n openebs --create-namespace \
 	--set ndmOperator.enabled=false \
 	--set localprovisioner.deviceClass.enabled=false
 ```
-  3. Install OpenEBS Dynamic LocalPV Provisioner with a custom hostpath directory. 
+  3. Install OpenEBS Dynamic LocalPV Provisioner with a custom hostpath directory.
      This will change the `BasePath` value for the 'openebs-hostpath' StorageClass.
 ```console
 helm install openebs openebs/openebs -n openebs --create-namespace \
@@ -92,6 +92,11 @@ You can provision LocalPV hostpath StorageType volumes dynamically using the def
        # hostpath directory
        #- name: BasePath
        #  value: "/var/openebs/local"
+       #Use this to set a specific mode for directory creation
+       #- name: FilePermissions
+       #  enabled: true
+       #  data:
+       #     mode: "0770"
   provisioner: openebs.io/local
   reclaimPolicy: Delete
   #It is necessary to have volumeBindingMode as WaitForFirstConsumer

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -94,7 +94,6 @@ You can provision LocalPV hostpath StorageType volumes dynamically using the def
        #  value: "/var/openebs/local"
        #Use this to set a specific mode for directory creation
        #- name: FilePermissions
-       #  enabled: true
        #  data:
        #     mode: "0770"
   provisioner: openebs.io/local

--- a/docs/tutorials/hostpath/filepermissions.md
+++ b/docs/tutorials/hostpath/filepermissions.md
@@ -1,0 +1,54 @@
+# File permission tuning
+
+Hostpath LocalPV will by default create folder with the following rights: `0777`. In some usecases, these rights are too wide and should be reduced.
+As an important point, when using hostpath the underlying PV will be a localpath whichs allows kubelet to chown the folder based on the [fsGroup](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods))
+
+We allow to reduce this filepermission using :
+
+```yaml
+  #This is a custom StorageClass template
+  apiVersion: storage.k8s.io/v1
+  kind: StorageClass
+  metadata:
+    name: custom-hostpath
+    annotations:
+      openebs.io/cas-type: local
+      cas.openebs.io/config: |
+        - name: StorageType
+          value: "hostpath"
+        - name: BasePath
+          value: "/var/openebs/local"
+        - name: FilePermissions
+          enabled: true
+          data:
+            mode: "0770"
+  provisioner: openebs.io/local
+  reclaimPolicy: Delete
+  #It is necessary to have volumeBindingMode as WaitForFirstConsumer
+  volumeBindingMode: WaitForFirstConsumer
+```
+
+With such configuration the folder will be crated with `0770` rights for all the PVC using this storage class.
+
+The same configuration is available at PVC level to have a more fined grained configuration capability (overrding the Storage class configuration level):
+
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: localpv-vol
+  annotations:
+    cas.openebs.io/config: |
+      - name: FilePermissions
+        enabled: true
+        data:
+          mode: "0770"
+spec:
+  #Change this name if you are using a custom StorageClass
+  storageClassName: openebs-hostpath
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      #Set capacity here
+      storage: 5Gi
+```

--- a/docs/tutorials/hostpath/filepermissions.md
+++ b/docs/tutorials/hostpath/filepermissions.md
@@ -19,7 +19,6 @@ We allow to set file permissions using:
         - name: BasePath
           value: "/var/openebs/local"
         - name: FilePermissions
-          enabled: true
           data:
             mode: "0770"
   provisioner: openebs.io/local
@@ -40,7 +39,6 @@ metadata:
   annotations:
     cas.openebs.io/config: |
       - name: FilePermissions
-        enabled: true
         data:
           mode: "0770"
 spec:

--- a/docs/tutorials/hostpath/filepermissions.md
+++ b/docs/tutorials/hostpath/filepermissions.md
@@ -3,7 +3,7 @@
 Hostpath LocalPV will by default create folder with the following rights: `0777`. In some usecases, these rights are too wide and should be reduced.
 As an important point, when using hostpath the underlying PV will be a localpath whichs allows kubelet to chown the folder based on the [fsGroup](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods))
 
-We allow to set file permissions using:  
+We allow to set file permissions using:
 
 ```yaml
   #This is a custom StorageClass template
@@ -30,7 +30,7 @@ We allow to set file permissions using:
 
 With such configuration the folder will be crated with `0770` rights for all the PVC using this storage class.
 
-The same configuration is available at PVC level to have a more fined grained configuration capability (overrding the Storage class configuration level):
+The same configuration is available at PVC level to have a more fined grained configuration capability (the Storage class configuration will always win against PVC one):
 
 ```yaml
 kind: PersistentVolumeClaim

--- a/docs/tutorials/hostpath/filepermissions.md
+++ b/docs/tutorials/hostpath/filepermissions.md
@@ -3,7 +3,7 @@
 Hostpath LocalPV will by default create folder with the following rights: `0777`. In some usecases, these rights are too wide and should be reduced.
 As an important point, when using hostpath the underlying PV will be a localpath whichs allows kubelet to chown the folder based on the [fsGroup](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods))
 
-We allow to reduce this filepermission using :
+We allow to set file permissions using:  
 
 ```yaml
   #This is a custom StorageClass template


### PR DESCRIPTION
## Pull Request template

**Why is this PR required? What issue does it fix?**:
Fixes https://github.com/openebs/dynamic-localpv-provisioner/issues/95.

**What this PR does?**:
It allows to configure default directory mode using LocaMode entry in cas.openebs.io/config.

**Does this PR require any upgrade changes?**: No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  annotations:
    cas.openebs.io/config: |
      - name: StorageType
        value: "hostpath"
      - name: BasePath
        value: "/opt/data/"
      - name: HostPathMode
        value: "770"
    openebs.io/cas-type: local
  name: local-path
provisioner: openebs.io/local
reclaimPolicy: Delete
volumeBindingMode: WaitForFirstConsumer
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: task-pv-claim
spec:
  storageClassName: local-path
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
---
apiVersion: v1
kind: Pod
metadata:
  name: task-pv-pod
spec:
  volumes:
    - name: task-pv-storage
      persistentVolumeClaim:
        claimName: task-pv-claim
  containers:
    - name: task-pv-container
      image: nginx
      ports:
        - containerPort: 80
          name: "http-server"
      volumeMounts:
        - mountPath: "/usr/share/nginx/html"
          name: task-pv-storage
```

check the file mode of the created folder (0770 instead of 0777)

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes #95
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [] Commit has unit tests
- [] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 

**PLEASE REMOVE BELOW INFORMATION BEFORE SUBMITTING**

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
