### PR TITLE
fix: quota is not calculated correctly

### DIFF
--- a/cmd/provisioner-localpv/app/helper_hostpath.go
+++ b/cmd/provisioner-localpv/app/helper_hostpath.go
@@ -107,7 +107,7 @@ func (pOpts *HelperPodOptions) validateLimits() error {
 		pOpts.hardLimitGrace == "0k" {
 		// Hack: using convertToK() style converstion
 		// TODO: Refactor this section of the code
-		pvcStorageInK := math.Ceil(float64(pOpts.pvcStorage) / 1000)
+		pvcStorageInK := math.Ceil(float64(pOpts.pvcStorage) / 1024)
 		pvcStorageInKString := strconv.FormatFloat(pvcStorageInK, 'f', -1, 64) + "k"
 		pOpts.softLimitGrace, pOpts.hardLimitGrace = pvcStorageInKString, pvcStorageInKString
 		return nil

--- a/cmd/provisioner-localpv/app/helper_hostpath.go
+++ b/cmd/provisioner-localpv/app/helper_hostpath.go
@@ -153,7 +153,7 @@ func convertToK(limit string, pvcStorage int64) (string, error) {
 	value *= float64(pvcStorage)
 	value /= 100
 	value += float64(pvcStorage)
-	value /= 1000
+	value /= 1024
 
 	value = math.Ceil(value)
 	valueString = strconv.FormatFloat(value, 'f', -1, 64)

--- a/cmd/provisioner-localpv/app/helper_test.go
+++ b/cmd/provisioner-localpv/app/helper_test.go
@@ -63,7 +63,7 @@ func TestConvertToK(t *testing.T) {
 				limit:      ".5%",
 				pvcStorage: 1000,
 			},
-			want:    "1k",
+			want:    "1k", // the final result of limit can't be a float
 			wantErr: false,
 		},
 		"Present limit grace with invalid pattern": {

--- a/cmd/provisioner-localpv/app/helper_test.go
+++ b/cmd/provisioner-localpv/app/helper_test.go
@@ -55,7 +55,7 @@ func TestConvertToK(t *testing.T) {
 				limit:      "200%",
 				pvcStorage: 5000000,
 			},
-			want:    "10000k",
+			want:    "9766k",
 			wantErr: false,
 		},
 		"Present limit grace with decimal%": {
@@ -63,7 +63,7 @@ func TestConvertToK(t *testing.T) {
 				limit:      ".5%",
 				pvcStorage: 1000,
 			},
-			want:    "2k",
+			want:    "1k",
 			wantErr: false,
 		},
 		"Present limit grace with invalid pattern": {


### PR DESCRIPTION
## Pull Request template

**Why is this PR required? What issue does it fix?**:

 If the pvc storage is 1G, which means 1073741824Byte. The quota returned from convertToK() is 1073742k which is bigger than expected. While, the correct result shall be 1048576k
![image](https://github.com/openebs/dynamic-localpv-provisioner/assets/74715700/1fea42eb-3887-4bca-a4be-b2907be04446)

**What this PR does?**:
Fix the quota calculation logic

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
The same scenariom, the quota returned is 1048576k after fix
![image](https://github.com/openebs/dynamic-localpv-provisioner/assets/74715700/d901f0f4-27dd-47d4-ae64-4f8687ec8276)



**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
