### PR TITLE
docs(device/nodeaffinitylabels): remove '-' from cas-config

### DIFF
--- a/docs/tutorials/device/nodeaffinitylabels.md
+++ b/docs/tutorials/device/nodeaffinitylabels.md
@@ -16,7 +16,7 @@ metadata:
     openebs.io/cas-type: local
     cas.openebs.io/config: |
       - name: StorageType
-      - value: "device"
+        value: "device"
       - name: NodeAffinityLabels
         list:
           - "openebs.io/custom-node-unique-id"


### PR DESCRIPTION
Fixes typo in cas-config in NodeAffnityLabels docs for localpv-device.