### PR TITLE
chore(deps): address CVE-2021-4238 from github.com/Masterminds/goutils

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,6 +87,7 @@ require (
 )
 
 replace (
+	github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1
 	k8s.io/api => k8s.io/api v0.25.16
 	k8s.io/apimachinery => k8s.io/apimachinery v0.25.16
 	k8s.io/client-go => k8s.io/client-go v0.25.16

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
-github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=


### PR DESCRIPTION
## Pull Request template

**Why is this PR required? What issue does it fix?**:

Removes vulnerability CVE-2021-4238

**What this PR does?**:

`github.com/Masterminds/goutils` v1.1.0 comes with vulnerability CVE-2021-4238. It is an indirect dependency from  github.com/openebs/maya. 

Best approach would be to upgrade maya dep, but this project is not being actively maintain (last release from 2021).

A second alternative is to replace the library github.com/Masteminds/sprig, but it uses goutils v1.1.1 only after version v3.2.1. The version change is too big.

The less intrusive approach is to replace gotutils version.

**Does this PR require any upgrade changes?**:

No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

```sh
# Identify from where the github.com/Mastermind/goutils originates
go mod why github.com/Mastermind/gotuils
# Make the change and update deps
make deps
# Verify the replace takes place
go list -m all | grep Masterminds
# Run tests
make tests
```

**Any additional information for your reviewer?** : 

No.

**Checklist:**
- [x] Fixes #170
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
  - NA   
- [ ] Commit has unit tests
  - NA
- [ ] Commit has integration tests
  - NA
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 

