### PR TITLE
Fix(Helm): Add pod priorityClassName to prevent race condition due to pod eviction

### DIFF
--- a/deploy/helm/charts/templates/deployment.yaml
+++ b/deploy/helm/charts/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
         {{ toYaml . | nindent 8 }}
         {{- end }}
     spec:
+    {{ with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+    {{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -55,6 +55,9 @@ localpv:
 imagePullSecrets:
   # - name: img-pull-secret
 
+## Sets priorityClassName in pod
+priorityClassName: ""
+
 podSecurityContext: {}
   # fsGroup: 2000
 


### PR DESCRIPTION
## Pull Request template

**Why is this PR required? What issue does it fix?**:
Allows to set `priorityClassName`, e.g `pod.spec.priorityClassName=system-node-critical`. Prevents a race condition where pod might get evicted after the node running the pod gets in condition `diskPressure=true`. Thus preventing the pod from doing its job of cleaning up the pvcs that cause the condition.

**What this PR does?**:
Allows to set `priorityClassName`

**Does this PR require any upgrade changes?**: no

**If the changes in this PR are manually verified, list down the scenarios covered:**:
- helm create
- helm upgrade
etc

**Any additional information for your reviewer?** : 
Critical for single-node clusters


**Checklist:**
- [x] Fixes (I did not create an issue as the issue is pretty straight forward to fix. Let me know if you want me to create an issue too)
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 

