### PR TITLE
revert: remove license-check which checks for license header 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: License Check
-        run: make license-check
-
   unit-test:
     # to ignore builds on release
     if: ${{ (github.event.ref_type != 'tag') }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -36,9 +36,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: License Check
-        run: make license-check
-
   unit-test:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -179,19 +179,6 @@ provisioner-localpv-image: provisioner-localpv
 	@cd buildscripts/provisioner-localpv && docker build -t ${PROVISIONER_LOCALPV_IMAGE_TAG} ${DBUILD_ARGS} . --no-cache
 	@rm buildscripts/provisioner-localpv/${PROVISIONER_LOCALPV}
 
-.PHONY: license-check
-license-check:
-	@echo "--> Checking license header..."
-	@licRes=$$(for file in $$(find . -type f -regex '.*\.sh\|.*\.go\|.*Docker.*\|.*\Makefile*') ; do \
-               awk 'NR<=5' $$file | grep -Eq "(Copyright|generated|GENERATED)" || echo $$file; \
-       done); \
-       if [ -n "$${licRes}" ]; then \
-               echo "license header checking failed:"; echo "$${licRes}"; \
-               exit 1; \
-       fi
-	@echo "--> Done checking license."
-	@echo
-
 
 .PHONY: push
 push:

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,3 @@
-# Copyright © 2020 The OpenEBS Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 GO111MODULE ?= on
 export GO111MODULE
 


### PR DESCRIPTION
Removes the CI job which checks all files for the Apache 2.0 header.
Removed the header from the Makefile.