### PR TITLE
feat: support helper pod to use hostNetwork

### DIFF
--- a/changelogs/unreleased/224-mctech
+++ b/changelogs/unreleased/224-mctech
@@ -1,0 +1,1 @@
+support helper pod to use hostNetwork

--- a/cmd/provisioner-localpv/app/env.go
+++ b/cmd/provisioner-localpv/app/env.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	menv "github.com/openebs/maya/pkg/env/v1alpha1"
+	k8sEnv "k8s.io/utils/env"
 )
 
 //This file defines the environement variable names that are specific
@@ -21,7 +22,7 @@ const (
 
 	// ProvisionerHelperPodHostNetwork is the environment variable that provides the
 	// host network mode to be used to launch the help pods
-	ProvisionerHelperPodHostNetwork menv.ENVKey = "OPENEBS_IO_HELPER_POD_HOST_NETWORK"
+	ProvisionerHelperPodHostNetwork string = "OPENEBS_IO_HELPER_POD_HOST_NETWORK"
 
 	// ProvisionerBasePath is the environment variable that provides the
 	// default base path on the node where host-path PVs will be provisioned.
@@ -44,10 +45,8 @@ func getDefaultHelperImage() string {
 	return menv.GetOrDefault(ProvisionerHelperImage, string(defaultHelperImage))
 }
 func getHelperPodHostNetwork() bool {
-	if hostNetwork := menv.GetOrDefault(ProvisionerHelperPodHostNetwork, "false"); hostNetwork == "true" {
-		return true
-	}
-	return false
+	val, _ := k8sEnv.GetBool(ProvisionerHelperPodHostNetwork, false)
+	return val
 }
 
 func getDefaultBasePath() string {

--- a/cmd/provisioner-localpv/app/env.go
+++ b/cmd/provisioner-localpv/app/env.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2019 The OpenEBS Authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package app
 
 import (
@@ -35,6 +19,10 @@ const (
 	// host path
 	ProvisionerHelperImage menv.ENVKey = "OPENEBS_IO_HELPER_IMAGE"
 
+	// ProvisionerHelperPodHostNetwork is the environment variable that provides the
+	// host network mode to be used to launch the help pods
+	ProvisionerHelperPodHostNetwork menv.ENVKey = "OPENEBS_IO_HELPER_POD_HOST_NETWORK"
+
 	// ProvisionerBasePath is the environment variable that provides the
 	// default base path on the node where host-path PVs will be provisioned.
 	ProvisionerBasePath menv.ENVKey = "OPENEBS_IO_BASE_PATH"
@@ -54,6 +42,12 @@ func getOpenEBSNamespace() string {
 }
 func getDefaultHelperImage() string {
 	return menv.GetOrDefault(ProvisionerHelperImage, string(defaultHelperImage))
+}
+func getHelperPodHostNetwork() bool {
+	if hostNetwork := menv.GetOrDefault(ProvisionerHelperPodHostNetwork, "false"); hostNetwork == "true" {
+		return true
+	}
+	return false
 }
 
 func getDefaultBasePath() string {

--- a/cmd/provisioner-localpv/app/env_test.go
+++ b/cmd/provisioner-localpv/app/env_test.go
@@ -1,24 +1,9 @@
-/*
-Copyright 2019 The OpenEBS Authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package app
 
 import (
 	"os"
 	"reflect"
+	"strconv"
 	"testing"
 
 	menv "github.com/openebs/maya/pkg/env/v1alpha1"
@@ -88,6 +73,40 @@ func TestGetDefaultHelperImage(t *testing.T) {
 				t.Errorf("expected %s got %s", v.expectValue, actualValue)
 			}
 			os.Unsetenv(string(ProvisionerHelperImage))
+		})
+	}
+}
+
+func TestGetHelperPodHostNetworke(t *testing.T) {
+	testCases := map[string]struct {
+		value       string
+		expectValue string
+	}{
+		"Missing env variable": {
+			value:       "",
+			expectValue: "false",
+		},
+		"Present env variable with value": {
+			value:       "value1",
+			expectValue: "false",
+		},
+		"Present env variable with whitespaces": {
+			value:       "true",
+			expectValue: "true",
+		},
+	}
+
+	for k, v := range testCases {
+		v := v
+		t.Run(k, func(t *testing.T) {
+			if len(v.value) != 0 {
+				os.Setenv(string(ProvisionerHelperPodHostNetwork), v.value)
+			}
+			actualValue := strconv.FormatBool(getHelperPodHostNetwork())
+			if !reflect.DeepEqual(actualValue, v.expectValue) {
+				t.Errorf("expected %s got %s", v.expectValue, actualValue)
+			}
+			os.Unsetenv(string(ProvisionerHelperPodHostNetwork))
 		})
 	}
 }

--- a/cmd/provisioner-localpv/app/helper_hostpath.go
+++ b/cmd/provisioner-localpv/app/helper_hostpath.go
@@ -1,22 +1,3 @@
-/*
-Copyright 2019 The OpenEBS Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-This code was taken from https://github.com/rancher/local-path-provisioner
-and modified to work with the configuration options used by OpenEBS
-*/
-
 package app
 
 import (
@@ -84,6 +65,9 @@ type HelperPodOptions struct {
 
 	//pvcStorage is the storage requested for pv
 	pvcStorage int64
+
+	//hostNetwork is the network type of helper Pod
+	hostNetwork bool
 }
 
 // validate checks that the required fields to launch
@@ -357,6 +341,7 @@ func (p *Provisioner) launchPod(ctx context.Context, config podConfig) (*corev1.
 				WithName("dev").
 				WithHostDirectory("/dev/"),
 		).
+		WithHostNetwork(config.pOpts.hostNetwork).
 		Build()
 
 	if err != nil {

--- a/deploy/helm/charts/templates/deployment.yaml
+++ b/deploy/helm/charts/templates/deployment.yaml
@@ -90,6 +90,8 @@ spec:
           value: "{{ .Values.localpv.basePath }}"
         - name: OPENEBS_IO_HELPER_IMAGE
           value: "{{ .Values.helperPod.image.registry }}{{ .Values.helperPod.image.repository }}:{{ .Values.helperPod.image.tag }}"
+        - name: OPENEBS_IO_HELPER_POD_HOST_NETWORK
+          value: "{{ .Values.helperPod.hostNetwork }}"
         - name: OPENEBS_IO_INSTALLER_TYPE
           value: "localpv-charts-helm"
         # LEADER_ELECTION_ENABLED is used to enable/disable leader election. By default

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -118,6 +118,7 @@ helperPod:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: 4.1.0
+  hostNetwork: false
 
 # Additional labels to add to all chart resources
 extraLabels: {}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2
 	k8s.io/klog/v2 v2.100.1
+	k8s.io/utils v0.0.0-20241210054802-24370beab758
 	sigs.k8s.io/sig-storage-lib-external-provisioner/v9 v9.0.3
 	sigs.k8s.io/yaml v1.3.0
 )
@@ -82,7 +83,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/klog v1.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20230525220651-2546d827e515 // indirect
-	k8s.io/utils v0.0.0-20230505201702-9f6742963106 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -990,8 +990,8 @@ k8s.io/kube-openapi v0.0.0-20230525220651-2546d827e515 h1:OmK1d0WrkD3IPfkskvroRy
 k8s.io/kube-openapi v0.0.0-20230525220651-2546d827e515/go.mod h1:kzo02I3kQ4BTtEfVLaPbjvCkX97YqGve33wzlb3fofQ=
 k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-k8s.io/utils v0.0.0-20230505201702-9f6742963106 h1:EObNQ3TW2D+WptiYXlApGNLVy0zm/JIBVY9i+M4wpAU=
-k8s.io/utils v0.0.0-20230505201702-9f6742963106/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+k8s.io/utils v0.0.0-20241210054802-24370beab758 h1:sdbE21q2nlQtFh65saZY+rRM6x6aJJI8IUa1AmH/qa0=
+k8s.io/utils v0.0.0-20241210054802-24370beab758/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/kubernetes/api/core/v1/pod/build.go
+++ b/pkg/kubernetes/api/core/v1/pod/build.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2019-2020 The OpenEBS Authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package pod
 
 import (
@@ -288,6 +272,13 @@ func (b *Builder) WithServiceAccountName(serviceAccountName string) *Builder {
 		return b
 	}
 	b.pod.object.Spec.ServiceAccountName = serviceAccountName
+	return b
+}
+
+// WithHostNetwork sets the hostNetwork of Pod spec with
+// the provided value
+func (b *Builder) WithHostNetwork(enabled bool) *Builder {
+	b.pod.object.Spec.HostNetwork = enabled
 	return b
 }
 


### PR DESCRIPTION
Pulling in @mctech's commit (PR #160) here.
>## Pull Request template
>
>**Why is this PR required? What issue does it fix?**:
>
>helper pod does not need a individual IP. setting `hostNetwork=true` can skip PodIP assignment step and accelerate helper pod creation. 
>
>**What this PR does?**:
>
>provide an option: support helper pod to use hostNetwork
>
>**Does this PR require any upgrade changes?**:
>
>**If the changes in this PR are manually verified, list down the scenarios covered:**:
>
>**Any additional information for your reviewer?** : 
>_Mention if this PR is part of any design or a continuation of previous PRs_
>
>
>**Checklist:**
>- [ ] Fixes #<issue number>
>- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
>- [ ] Has the change log section been updated? 
>- [ ] Commit has unit tests
>- [ ] Commit has integration tests
>- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
>- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 