### PR TITLE
fix: pod crashed when creating init pod, new pod always fail because the init pod already exists

### DIFF
--- a/cmd/provisioner-localpv/app/helper_hostpath.go
+++ b/cmd/provisioner-localpv/app/helper_hostpath.go
@@ -317,8 +317,8 @@ func (p *Provisioner) launchPod(ctx context.Context, config podConfig) (*corev1.
 		return nil, err
 	}
 	if podList.Items != nil && len(podList.Items) != 0 {
-		klog.Infof("existing helper podList length: %d", len(podList.Items))
-		klog.Infof("existing helper pod: %v", podList.Items[0])
+		klog.V(2).Infof("existing helper podList length: %d", len(podList.Items))
+		klog.V(2).Infof("existing helper pod: %s/%s", podList.Items[0].Namespace, podList.Items[0].Name)
 		return &podList.Items[0], nil
 	}
 

--- a/cmd/provisioner-localpv/app/helper_hostpath.go
+++ b/cmd/provisioner-localpv/app/helper_hostpath.go
@@ -12,6 +12,7 @@ import (
 	hostpath "github.com/openebs/maya/pkg/hostpath/v1alpha1"
 	errors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
@@ -215,7 +216,7 @@ func (p *Provisioner) createCleanupPod(ctx context.Context, pOpts *HelperPodOpti
 	config.pOpts.cmdsForPath = append(config.pOpts.cmdsForPath, filepath.Join("/data/", config.volumeDir))
 
 	cPod, err := p.launchPod(ctx, config)
-	if err != nil {
+	if err != nil && !k8serror.IsAlreadyExists(err) {
 		return err
 	}
 
@@ -287,7 +288,7 @@ func (p *Provisioner) createQuotaPod(ctx context.Context, pOpts *HelperPodOption
 	config.pOpts.cmdsForPath = []string{"sh", "-c", fs + checkQuota}
 
 	qPod, err := p.launchPod(ctx, config)
-	if err != nil {
+	if err != nil && !k8serror.IsAlreadyExists(err) {
 		return err
 	}
 

--- a/cmd/provisioner-localpv/app/helper_hostpath.go
+++ b/cmd/provisioner-localpv/app/helper_hostpath.go
@@ -174,12 +174,12 @@ func (p *Provisioner) createInitPod(ctx context.Context, pOpts *HelperPodOptions
 
 	config.pOpts.cmdsForPath = append(config.pOpts.cmdsForPath, filepath.Join("/data/", config.volumeDir))
 
-	_, err := p.launchPod(ctx, config)
+	iPod, err := p.launchPod(ctx, config)
 	if err != nil {
 		return err
 	}
 
-	if err := p.exitPod(ctx, config.podName+"-"+config.pOpts.name); err != nil {
+	if err := p.exitPod(ctx, iPod); err != nil {
 		return err
 	}
 
@@ -215,12 +215,12 @@ func (p *Provisioner) createCleanupPod(ctx context.Context, pOpts *HelperPodOpti
 
 	config.pOpts.cmdsForPath = append(config.pOpts.cmdsForPath, filepath.Join("/data/", config.volumeDir))
 
-	_, err := p.launchPod(ctx, config)
+	cPod, err := p.launchPod(ctx, config)
 	if err != nil {
 		return err
 	}
 
-	if err := p.exitPod(ctx, config.podName+"-"+config.pOpts.name); err != nil {
+	if err := p.exitPod(ctx, cPod); err != nil {
 		return err
 	}
 	return nil
@@ -287,12 +287,12 @@ func (p *Provisioner) createQuotaPod(ctx context.Context, pOpts *HelperPodOption
 		"  rm -rf " + filepath.Join("/data/", config.volumeDir) + " ; exit 1; fi"
 	config.pOpts.cmdsForPath = []string{"sh", "-c", fs + checkQuota}
 
-	_, err := p.launchPod(ctx, config)
+	qPod, err := p.launchPod(ctx, config)
 	if err != nil {
 		return err
 	}
 
-	if err := p.exitPod(ctx, config.podName+"-"+config.pOpts.name); err != nil {
+	if err := p.exitPod(ctx, qPod); err != nil {
 		return err
 	}
 
@@ -371,9 +371,9 @@ func (p *Provisioner) launchPod(ctx context.Context, config podConfig) (*corev1.
 	return hPod, err
 }
 
-func (p *Provisioner) exitPod(ctx context.Context, hPodName string) error {
+func (p *Provisioner) exitPod(ctx context.Context, hPod *corev1.Pod) error {
 	defer func() {
-		e := p.kubeClient.CoreV1().Pods(p.namespace).Delete(ctx, hPodName, metav1.DeleteOptions{})
+		e := p.kubeClient.CoreV1().Pods(p.namespace).Delete(ctx, hPod.Name, metav1.DeleteOptions{})
 		if e != nil {
 			klog.Errorf("unable to delete the helper pod: %v", e)
 		}
@@ -382,7 +382,7 @@ func (p *Provisioner) exitPod(ctx context.Context, hPodName string) error {
 	//Wait for the helper pod to complete it job and exit
 	completed := false
 	for i := 0; i < CmdTimeoutCounts; i++ {
-		checkPod, err := p.kubeClient.CoreV1().Pods(p.namespace).Get(ctx, hPodName, metav1.GetOptions{})
+		checkPod, err := p.kubeClient.CoreV1().Pods(p.namespace).Get(ctx, hPod.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		} else if checkPod.Status.Phase == corev1.PodSucceeded {

--- a/cmd/provisioner-localpv/app/helper_hostpath.go
+++ b/cmd/provisioner-localpv/app/helper_hostpath.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/labels"
 	"math"
 	"path/filepath"
 	"regexp"
@@ -14,6 +13,7 @@ import (
 	errors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
 
 	"github.com/openebs/dynamic-localpv-provisioner/pkg/kubernetes/api/core/v1/container"
@@ -308,6 +308,7 @@ func (p *Provisioner) launchPod(ctx context.Context, config podConfig) (*corev1.
 	matchLabels := map[string]string{
 		"openebs.io/pvc-name":      config.pOpts.name,
 		"openebs.io/pvc-namespace": p.namespace,
+		"openebs.io/helper-type":   "hostpath-" + config.podName,
 	}
 	podList, err := p.kubeClient.CoreV1().Pods(p.namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: labels.Set(matchLabels).String(),
@@ -316,6 +317,8 @@ func (p *Provisioner) launchPod(ctx context.Context, config podConfig) (*corev1.
 		return nil, err
 	}
 	if podList.Items != nil && len(podList.Items) != 0 {
+		klog.Infof("existing helper podList length: %d", len(podList.Items))
+		klog.Infof("existing helper pod: %v", podList.Items[0])
 		return &podList.Items[0], nil
 	}
 

--- a/cmd/provisioner-localpv/app/helper_hostpath.go
+++ b/cmd/provisioner-localpv/app/helper_hostpath.go
@@ -174,12 +174,12 @@ func (p *Provisioner) createInitPod(ctx context.Context, pOpts *HelperPodOptions
 
 	config.pOpts.cmdsForPath = append(config.pOpts.cmdsForPath, filepath.Join("/data/", config.volumeDir))
 
-	iPod, err := p.launchPod(ctx, config)
+	_, err := p.launchPod(ctx, config)
 	if err != nil && !k8serror.IsAlreadyExists(err) {
 		return err
 	}
 
-	if err := p.exitPod(ctx, iPod); err != nil {
+	if err := p.exitPod(ctx, config.podName+"-"+config.pOpts.name); err != nil {
 		return err
 	}
 
@@ -215,12 +215,12 @@ func (p *Provisioner) createCleanupPod(ctx context.Context, pOpts *HelperPodOpti
 
 	config.pOpts.cmdsForPath = append(config.pOpts.cmdsForPath, filepath.Join("/data/", config.volumeDir))
 
-	cPod, err := p.launchPod(ctx, config)
+	_, err := p.launchPod(ctx, config)
 	if err != nil && !k8serror.IsAlreadyExists(err) {
 		return err
 	}
 
-	if err := p.exitPod(ctx, cPod); err != nil {
+	if err := p.exitPod(ctx, config.podName+"-"+config.pOpts.name); err != nil {
 		return err
 	}
 	return nil
@@ -287,12 +287,12 @@ func (p *Provisioner) createQuotaPod(ctx context.Context, pOpts *HelperPodOption
 		"  rm -rf " + filepath.Join("/data/", config.volumeDir) + " ; exit 1; fi"
 	config.pOpts.cmdsForPath = []string{"sh", "-c", fs + checkQuota}
 
-	qPod, err := p.launchPod(ctx, config)
+	_, err := p.launchPod(ctx, config)
 	if err != nil && !k8serror.IsAlreadyExists(err) {
 		return err
 	}
 
-	if err := p.exitPod(ctx, qPod); err != nil {
+	if err := p.exitPod(ctx, config.podName+"-"+config.pOpts.name); err != nil {
 		return err
 	}
 
@@ -356,9 +356,9 @@ func (p *Provisioner) launchPod(ctx context.Context, config podConfig) (*corev1.
 	return hPod, err
 }
 
-func (p *Provisioner) exitPod(ctx context.Context, hPod *corev1.Pod) error {
+func (p *Provisioner) exitPod(ctx context.Context, hPodName string) error {
 	defer func() {
-		e := p.kubeClient.CoreV1().Pods(p.namespace).Delete(ctx, hPod.Name, metav1.DeleteOptions{})
+		e := p.kubeClient.CoreV1().Pods(p.namespace).Delete(ctx, hPodName, metav1.DeleteOptions{})
 		if e != nil {
 			klog.Errorf("unable to delete the helper pod: %v", e)
 		}
@@ -367,7 +367,7 @@ func (p *Provisioner) exitPod(ctx context.Context, hPod *corev1.Pod) error {
 	//Wait for the helper pod to complete it job and exit
 	completed := false
 	for i := 0; i < CmdTimeoutCounts; i++ {
-		checkPod, err := p.kubeClient.CoreV1().Pods(p.namespace).Get(ctx, hPod.Name, metav1.GetOptions{})
+		checkPod, err := p.kubeClient.CoreV1().Pods(p.namespace).Get(ctx, hPodName, metav1.GetOptions{})
 		if err != nil {
 			return err
 		} else if checkPod.Status.Phase == corev1.PodSucceeded {

--- a/cmd/provisioner-localpv/app/helper_hostpath.go
+++ b/cmd/provisioner-localpv/app/helper_hostpath.go
@@ -12,8 +12,8 @@ import (
 	hostpath "github.com/openebs/maya/pkg/hostpath/v1alpha1"
 	errors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
 
 	"github.com/openebs/dynamic-localpv-provisioner/pkg/kubernetes/api/core/v1/container"
@@ -175,7 +175,7 @@ func (p *Provisioner) createInitPod(ctx context.Context, pOpts *HelperPodOptions
 	config.pOpts.cmdsForPath = append(config.pOpts.cmdsForPath, filepath.Join("/data/", config.volumeDir))
 
 	iPod, err := p.launchPod(ctx, config)
-	if err != nil {
+	if err != nil && !k8serror.IsAlreadyExists(err) {
 		return err
 	}
 
@@ -216,7 +216,7 @@ func (p *Provisioner) createCleanupPod(ctx context.Context, pOpts *HelperPodOpti
 	config.pOpts.cmdsForPath = append(config.pOpts.cmdsForPath, filepath.Join("/data/", config.volumeDir))
 
 	cPod, err := p.launchPod(ctx, config)
-	if err != nil {
+	if err != nil && !k8serror.IsAlreadyExists(err) {
 		return err
 	}
 
@@ -288,7 +288,7 @@ func (p *Provisioner) createQuotaPod(ctx context.Context, pOpts *HelperPodOption
 	config.pOpts.cmdsForPath = []string{"sh", "-c", fs + checkQuota}
 
 	qPod, err := p.launchPod(ctx, config)
-	if err != nil {
+	if err != nil && !k8serror.IsAlreadyExists(err) {
 		return err
 	}
 
@@ -304,23 +304,6 @@ func (p *Provisioner) launchPod(ctx context.Context, config podConfig) (*corev1.
 	// nodes, pods without privileged access cannot write to the host directory.
 	// Helper pods need to create and delete directories on the host.
 	privileged := true
-
-	matchLabels := map[string]string{
-		"openebs.io/pvc-name":      config.pOpts.name,
-		"openebs.io/pvc-namespace": p.namespace,
-		"openebs.io/helper-type":   "hostpath-" + config.podName,
-	}
-	podList, err := p.kubeClient.CoreV1().Pods(p.namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: labels.Set(matchLabels).String(),
-	})
-	if err != nil {
-		return nil, err
-	}
-	if podList.Items != nil && len(podList.Items) != 0 {
-		klog.V(2).Infof("existing helper podList length: %d", len(podList.Items))
-		klog.V(2).Infof("existing helper pod: %s/%s", podList.Items[0].Namespace, podList.Items[0].Name)
-		return &podList.Items[0], nil
-	}
 
 	helperPod, err := pod.NewBuilder().
 		WithName(config.podName + "-" + config.pOpts.name).
@@ -360,7 +343,6 @@ func (p *Provisioner) launchPod(ctx context.Context, config podConfig) (*corev1.
 				WithHostDirectory("/dev/"),
 		).
 		WithHostNetwork(config.pOpts.hostNetwork).
-		WithLabels(matchLabels).
 		Build()
 
 	if err != nil {


### PR DESCRIPTION
## Pull Request template

**Why is this PR required? What issue does it fix?**:
dynamic-localpv-provisioner pod crashed(for example: crashed because of renewing lease failed) when creating init pod, new provisioner pod starts, and it continues creating volume. But it always fails because the init pod already exists. So the pvc will always be pending status.

**What this PR does?**:
When creating init pods, it would ignore `pod existes error`.

**Does this PR require any upgrade changes?**:
No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes #<[225](https://github.com/openebs/dynamic-localpv-provisioner/issues/225)>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 