### PR TITLE
ci: pin medyagh/setup-minikube runs to ubuntu-22.04

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -63,7 +63,7 @@ jobs:
           flags: unittests
 
   integration-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: ['lint', 'unit-test']
     strategy:
       matrix:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -78,7 +78,7 @@ jobs:
           flags: unittests
 
   integration-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: ['lint', 'unit-test']
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
           flags: unittests
 
   integration-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: ['lint', 'unit-test']
     strategy:
       matrix:


### PR DESCRIPTION
Ref: https://github.com/medyagh/setup-minikube/issues/565

ubuntu-latest roughly translates to ubuntu-24.04 at this point in time. However, the issue above interrupts our intergration test runs. Pinning ubuntu to 22.04 to get around this issue.