### PR TITLE
feat: Add support to specify file permissions for pvc hostpaths

### DIFF
--- a/cmd/provisioner-localpv/app/config.go
+++ b/cmd/provisioner-localpv/app/config.go
@@ -113,6 +113,26 @@ const (
 
 	KeyQuotaSoftLimit = "softLimitGrace"
 	KeyQuotaHardLimit = "hardLimitGrace"
+
+	// FilePermissions allows to define the default directory mode
+	// Exemple StorageClass snippet:
+	//    - name: FilePermissions
+	//      enabled: true
+	//      data:
+	//        UID: 1000
+	//        GID: 1000
+	//        mode: g+s
+	// This is the cas-template key for all file permission 'data' keys
+	KeyFilePermissions = "FilePermissions"
+
+	// FsUID defines the user owner of the shared directory
+	KeyFsUID = "UID"
+
+	// FsGID defines the group owner of the shared directory
+	KeyFsGID = "GID"
+
+	// FSMode defines the file permission mode of the shared directory
+	KeyFsMode = "mode"
 )
 
 const (
@@ -152,21 +172,20 @@ func (p *Provisioner) GetVolumeConfig(ctx context.Context, pvName string, pvc *c
 		}
 	}
 
-	// Extract and merge the cas config from persistentvolumeclaim.
-	// TODO: Validation checks for what all cas-config options can be
-	// set on the PVC.
-	pvcCASConfigStr := pvc.Annotations[string(mconfig.CASConfigKey)]
+	//TODO : extract and merge the cas volume config from pvc
+	// This block can be added once validation checks are added
+	// as to the type of config that can be passed via PVC
+	pvcCASConfigStr := pvc.ObjectMeta.Annotations[string(mconfig.CASConfigKey)]
 	klog.V(4).Infof("PVC %v has config:%v", pvc.Name, pvcCASConfigStr)
 	if len(strings.TrimSpace(pvcCASConfigStr)) != 0 {
 		pvcCASConfig, err := cast.UnMarshallToConfig(pvcCASConfigStr)
 		if err == nil {
-			// Config keys which already exist (SC config),
-			// will be skipped
-			// i.e. SC config will have precedence over PVC config,
-			// if both have the same keys
-			pvConfig = cast.MergeConfig(pvConfig, pvcCASConfig)
+			pvConfig = cast.MergeConfig(pvcCASConfig, pvConfig)
 		} else {
-			return nil, errors.Wrapf(err, "failed to get config: invalid pvc config {%v}", pvcCASConfigStr)
+			return nil, errors.Wrapf(err, "failed to get config: invalid config {%v}"+
+				" in pvc {%v} in namespace {%v}",
+				pvcCASConfigStr, pvc.Name, pvc.Namespace,
+			)
 		}
 	}
 
@@ -330,6 +349,68 @@ func (c *VolumeConfig) IsExt4QuotaEnabled() bool {
 	}
 
 	return enableExt4QuotaBool
+}
+
+func (c *VolumeConfig) IsPermissionEnabled() bool {
+	permissionEnabled := c.getEnabled(KeyFilePermissions)
+	permissionEnabled = strings.TrimSpace(permissionEnabled)
+
+	permissionEnabledQuotaBool, err := strconv.ParseBool(permissionEnabled)
+	//Default case
+	// this means that we have hit either of the two cases below:
+	//     i. The value was something other than a straightforward
+	//        true or false
+	//    ii. The value was empty
+	if err != nil {
+		return false
+	}
+
+	return permissionEnabledQuotaBool
+}
+
+// GetFsGID fetches the group owner's ID from
+// PVC annotation, if specified
+// NOT YET USED
+func (c *VolumeConfig) GetFsGID() string {
+	if c.IsPermissionEnabled() {
+		configData := c.getData(KeyFilePermissions)
+		if configData != nil {
+			if val, p := configData[KeyFsGID]; p {
+				return strings.TrimSpace(val)
+			}
+		}
+	}
+	return ""
+}
+
+// GetFsGID fetches the user owner's ID from
+// PVC annotation, if specified
+// NOT YET USED
+func (c *VolumeConfig) GetFsUID() string {
+	if c.IsPermissionEnabled() {
+		configData := c.getData(KeyFilePermissions)
+		if configData != nil {
+			if val, p := configData[KeyFsUID]; p {
+				return strings.TrimSpace(val)
+			}
+		}
+	}
+	return ""
+}
+
+// GetFsMode fetches the file mode from PVC
+// or StorageClass annotation, if specified
+func (c *VolumeConfig) GetFsMode() string {
+	if c.IsPermissionEnabled() {
+		configData := c.getData(KeyFilePermissions)
+		if configData != nil {
+			if val, p := configData[KeyFsMode]; p {
+				return strings.TrimSpace(val)
+			}
+		}
+	}
+	//Keep the original default mode
+	return "0777"
 }
 
 // getValue is a utility function to extract the value

--- a/cmd/provisioner-localpv/app/config.go
+++ b/cmd/provisioner-localpv/app/config.go
@@ -2,11 +2,11 @@ package app
 
 import (
 	"context"
+	"gopkg.in/yaml.v3"
 	"strconv"
 	"strings"
 
 	mconfig "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
-	cast "github.com/openebs/maya/pkg/castemplate/v1alpha1"
 	hostpath "github.com/openebs/maya/pkg/hostpath/v1alpha1"
 	"github.com/openebs/maya/pkg/util"
 	"github.com/pkg/errors"
@@ -118,8 +118,6 @@ const (
 	// Exemple StorageClass snippet:
 	//    - name: FilePermissions
 	//      data:
-	//        UID: 1000
-	//        GID: 1000
 	//        mode: g+s
 	// This is the cas-template key for all file permission 'data' keys
 	KeyFilePermissions = "FilePermissions"
@@ -144,7 +142,7 @@ const (
 // default configuration of the provisioner.
 func (p *Provisioner) GetVolumeConfig(ctx context.Context, pvName string, pvc *corev1.PersistentVolumeClaim) (*VolumeConfig, error) {
 
-	pvConfig := p.defaultConfig
+	var pvConfig []Config
 
 	//Fetch the SC
 	scName := GetStorageClassName(pvc)
@@ -155,11 +153,12 @@ func (p *Provisioner) GetVolumeConfig(ctx context.Context, pvName string, pvc *c
 
 	// extract and merge the cas config from storageclass
 	scCASConfigStr := sc.ObjectMeta.Annotations[string(mconfig.CASConfigKey)]
+	var scConfig []Config
 	klog.V(4).Infof("SC %v has config:%v", *scName, scCASConfigStr)
 	if len(strings.TrimSpace(scCASConfigStr)) != 0 {
-		scCASConfig, err := cast.UnMarshallToConfig(scCASConfigStr)
+		err = yaml.Unmarshal([]byte(scCASConfigStr), &scConfig)
 		if err == nil {
-			pvConfig = cast.MergeConfig(scCASConfig, pvConfig)
+			pvConfig = MergeConfigs(scConfig, pvConfig)
 		} else {
 			return nil, errors.Wrapf(err, "failed to get config: invalid sc config {%v}", scCASConfigStr)
 		}
@@ -168,12 +167,13 @@ func (p *Provisioner) GetVolumeConfig(ctx context.Context, pvName string, pvc *c
 	//TODO : extract and merge the cas volume config from pvc
 	// This block can be added once validation checks are added
 	// as to the type of config that can be passed via PVC
+	var pvcConfig []Config
 	pvcCASConfigStr := pvc.ObjectMeta.Annotations[string(mconfig.CASConfigKey)]
 	klog.V(4).Infof("PVC %v has config:%v", pvc.Name, pvcCASConfigStr)
 	if len(strings.TrimSpace(pvcCASConfigStr)) != 0 {
-		pvcCASConfig, err := cast.UnMarshallToConfig(pvcCASConfigStr)
+		err = yaml.Unmarshal([]byte(pvcCASConfigStr), &pvcConfig)
 		if err == nil {
-			pvConfig = cast.MergeConfig(pvConfig, pvcCASConfig)
+			pvConfig = MergeConfigs(pvConfig, pvcConfig)
 		} else {
 			return nil, errors.Wrapf(err, "failed to get config: invalid config {%v}"+
 				" in pvc {%v} in namespace {%v}",
@@ -182,7 +182,7 @@ func (p *Provisioner) GetVolumeConfig(ctx context.Context, pvName string, pvc *c
 		}
 	}
 
-	pvConfigMap, err := cast.ConfigToMap(pvConfig)
+	pvConfigMap, err := ConfigToMap(pvConfig)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to read volume config: pvc {%v}", pvc.ObjectMeta.Name)
 	}
@@ -347,14 +347,10 @@ func (c *VolumeConfig) IsExt4QuotaEnabled() bool {
 // GetFsMode fetches the file mode from PVC
 // or StorageClass annotation, if specified
 func (c *VolumeConfig) GetFsMode() string {
-	configData := c.getData(KeyFilePermissions)
-	if configData != nil {
-		if val, p := configData[KeyFsMode]; p {
-			return strings.TrimSpace(val)
-		}
-	}
+	configData := c.getDataField(KeyFilePermissions, KeyFsMode)
+
 	//Keep the original default mode
-	return ""
+	return configData
 }
 
 // getValue is a utility function to extract the value
@@ -396,9 +392,9 @@ func (c *VolumeConfig) getEnabled(key string) string {
 // This gets the value for a specific
 // 'Data' parameter key-value pair.
 func (c *VolumeConfig) getDataField(key string, dataKey string) string {
-	if configData, ok := util.GetNestedField(c.configData, key).(map[string]string); ok {
+	if configData, ok := util.GetNestedField(c.configData, key).(map[string]RawLiteral); ok {
 		if val, p := configData[dataKey]; p {
-			return val
+			return string(val)
 		}
 	}
 	//Default case
@@ -489,7 +485,7 @@ func GetImagePullSecrets(s string) []corev1.LocalObjectReference {
 	return list
 }
 
-func dataConfigToMap(pvConfig []mconfig.Config) (map[string]interface{}, error) {
+func dataConfigToMap(pvConfig []Config) (map[string]interface{}, error) {
 	m := map[string]interface{}{}
 
 	for _, configObj := range pvConfig {
@@ -511,7 +507,7 @@ func dataConfigToMap(pvConfig []mconfig.Config) (map[string]interface{}, error) 
 	return m, nil
 }
 
-func listConfigToMap(pvConfig []mconfig.Config) (map[string]interface{}, error) {
+func listConfigToMap(pvConfig []Config) (map[string]interface{}, error) {
 	m := map[string]interface{}{}
 
 	for _, configObj := range pvConfig {
@@ -531,4 +527,75 @@ func listConfigToMap(pvConfig []mconfig.Config) (map[string]interface{}, error) 
 	}
 
 	return m, nil
+}
+
+// A RawLiteral interprets characters as they are without assuming they are octal and translating them to ints.
+// This works when we want to pick up a yaml value as it is, whether it's wearing ” or "" or neither.
+type RawLiteral string
+
+func (r *RawLiteral) UnmarshalYAML(node *yaml.Node) error {
+	*r = RawLiteral(node.Value)
+	return nil
+}
+
+// Config holds a configuration element
+type Config struct {
+	// Name of the config
+	Name string `yaml:"name"`
+	// Enabled flags if this config is enabled or disabled;
+	// true indicates enabled while false indicates disabled
+	Enabled string `yaml:"enabled"`
+	// Value represents any specific value that is applicable
+	// to this config
+	Value string `yaml:"value"`
+	// Data represents an arbitrary map of key value pairs
+	Data map[string]RawLiteral `yaml:"data"`
+	// List represents a JSON(YAML) array
+	List []string `yaml:"list"`
+}
+
+// MergeConfig will merge configuration fields
+// from lowPriority that are not present in
+// highPriority configuration and return the
+// resulting config
+func MergeConfigs(highPriority, lowPriority []Config) (final []Config) {
+	var book []string
+	for _, h := range highPriority {
+		final = append(final, h)
+		book = append(book, strings.TrimSpace(h.Name))
+	}
+	for _, l := range lowPriority {
+		// include only if the config was not present
+		// earlier in high priority configuration
+		if !util.ContainsString(book, strings.TrimSpace(l.Name)) {
+			final = append(final, l)
+		}
+	}
+	return
+}
+
+// ConfigToMap transforms CAS template config type
+// to a nested map
+func ConfigToMap(all []Config) (m map[string]interface{}, err error) {
+	var configName string
+	m = map[string]interface{}{}
+	for _, config := range all {
+		configName = strings.TrimSpace(config.Name)
+		if len(configName) == 0 {
+			err = errors.Errorf("failed to transform cas config to map: missing config name: %s", config)
+			return nil, err
+		}
+		confHierarchy := map[string]interface{}{
+			configName: map[string]string{
+				"enabled": config.Enabled,
+				"value":   config.Value,
+			},
+		}
+		isMerged := util.MergeMapOfObjects(m, confHierarchy)
+		if !isMerged {
+			err = errors.Errorf("failed to transform cas config to map: failed to merge: %s", config)
+			return nil, err
+		}
+	}
+	return
 }

--- a/cmd/provisioner-localpv/app/config.go
+++ b/cmd/provisioner-localpv/app/config.go
@@ -180,7 +180,7 @@ func (p *Provisioner) GetVolumeConfig(ctx context.Context, pvName string, pvc *c
 	if len(strings.TrimSpace(pvcCASConfigStr)) != 0 {
 		pvcCASConfig, err := cast.UnMarshallToConfig(pvcCASConfigStr)
 		if err == nil {
-			pvConfig = cast.MergeConfig(pvcCASConfig, pvConfig)
+			pvConfig = cast.MergeConfig(pvConfig, pvcCASConfig)
 		} else {
 			return nil, errors.Wrapf(err, "failed to get config: invalid config {%v}"+
 				" in pvc {%v} in namespace {%v}",

--- a/cmd/provisioner-localpv/app/config.go
+++ b/cmd/provisioner-localpv/app/config.go
@@ -117,7 +117,6 @@ const (
 	// FilePermissions allows to define the default directory mode
 	// Exemple StorageClass snippet:
 	//    - name: FilePermissions
-	//      enabled: true
 	//      data:
 	//        UID: 1000
 	//        GID: 1000
@@ -345,32 +344,13 @@ func (c *VolumeConfig) IsExt4QuotaEnabled() bool {
 	return enableExt4QuotaBool
 }
 
-func (c *VolumeConfig) IsPermissionEnabled() bool {
-	permissionEnabled := c.getEnabled(KeyFilePermissions)
-	permissionEnabled = strings.TrimSpace(permissionEnabled)
-
-	permissionEnabledQuotaBool, err := strconv.ParseBool(permissionEnabled)
-	//Default case
-	// this means that we have hit either of the two cases below:
-	//     i. The value was something other than a straightforward
-	//        true or false
-	//    ii. The value was empty
-	if err != nil {
-		return false
-	}
-
-	return permissionEnabledQuotaBool
-}
-
 // GetFsMode fetches the file mode from PVC
 // or StorageClass annotation, if specified
 func (c *VolumeConfig) GetFsMode() string {
-	if c.IsPermissionEnabled() {
-		configData := c.getData(KeyFilePermissions)
-		if configData != nil {
-			if val, p := configData[KeyFsMode]; p {
-				return strings.TrimSpace(val)
-			}
+	configData := c.getData(KeyFilePermissions)
+	if configData != nil {
+		if val, p := configData[KeyFsMode]; p {
+			return strings.TrimSpace(val)
 		}
 	}
 	//Keep the original default mode

--- a/cmd/provisioner-localpv/app/config.go
+++ b/cmd/provisioner-localpv/app/config.go
@@ -125,12 +125,6 @@ const (
 	// This is the cas-template key for all file permission 'data' keys
 	KeyFilePermissions = "FilePermissions"
 
-	// FsUID defines the user owner of the shared directory
-	KeyFsUID = "UID"
-
-	// FsGID defines the group owner of the shared directory
-	KeyFsGID = "GID"
-
 	// FSMode defines the file permission mode of the shared directory
 	KeyFsMode = "mode"
 )
@@ -366,36 +360,6 @@ func (c *VolumeConfig) IsPermissionEnabled() bool {
 	}
 
 	return permissionEnabledQuotaBool
-}
-
-// GetFsGID fetches the group owner's ID from
-// PVC annotation, if specified
-// NOT YET USED
-func (c *VolumeConfig) GetFsGID() string {
-	if c.IsPermissionEnabled() {
-		configData := c.getData(KeyFilePermissions)
-		if configData != nil {
-			if val, p := configData[KeyFsGID]; p {
-				return strings.TrimSpace(val)
-			}
-		}
-	}
-	return ""
-}
-
-// GetFsGID fetches the user owner's ID from
-// PVC annotation, if specified
-// NOT YET USED
-func (c *VolumeConfig) GetFsUID() string {
-	if c.IsPermissionEnabled() {
-		configData := c.getData(KeyFilePermissions)
-		if configData != nil {
-			if val, p := configData[KeyFsUID]; p {
-				return strings.TrimSpace(val)
-			}
-		}
-	}
-	return ""
 }
 
 // GetFsMode fetches the file mode from PVC

--- a/cmd/provisioner-localpv/app/config.go
+++ b/cmd/provisioner-localpv/app/config.go
@@ -410,7 +410,7 @@ func (c *VolumeConfig) GetFsMode() string {
 		}
 	}
 	//Keep the original default mode
-	return "0777"
+	return ""
 }
 
 // getValue is a utility function to extract the value

--- a/cmd/provisioner-localpv/app/config_test.go
+++ b/cmd/provisioner-localpv/app/config_test.go
@@ -105,6 +105,43 @@ func TestDataConfigToMap(t *testing.T) {
 	}
 }
 
+func TestPermissionConfigToMap(t *testing.T) {
+	hostpathConfig := mconfig.Config{Name: "StorageType", Value: "hostpath"}
+	permissionConfig := mconfig.Config{Name: "FilePermissions", Enabled: "true",
+		Data: map[string]string{
+			"mode": "0750",
+		},
+	}
+
+	testCases := map[string]struct {
+		config        []mconfig.Config
+		expectedValue map[string]interface{}
+	}{
+		"nil 'Data' map": {
+			config: []mconfig.Config{hostpathConfig, permissionConfig},
+			expectedValue: map[string]interface{}{
+				"FilePermissions": map[string]string{
+					"mode": "0750",
+				},
+			},
+		},
+	}
+
+	for k, v := range testCases {
+		v := v
+		k := k
+		t.Run(k, func(t *testing.T) {
+			actualValue, err := dataConfigToMap(v.config)
+			if err != nil {
+				t.Errorf("expected error to be nil, but got %v", err)
+			}
+			if !reflect.DeepEqual(actualValue, v.expectedValue) {
+				t.Errorf("expected %v, but got %v", v.expectedValue, actualValue)
+			}
+		})
+	}
+}
+
 func Test_listConfigToMap(t *testing.T) {
 	tests := map[string]struct {
 		pvConfig      []mconfig.Config

--- a/cmd/provisioner-localpv/app/config_test.go
+++ b/cmd/provisioner-localpv/app/config_test.go
@@ -107,7 +107,7 @@ func TestDataConfigToMap(t *testing.T) {
 
 func TestPermissionConfigToMap(t *testing.T) {
 	hostpathConfig := mconfig.Config{Name: "StorageType", Value: "hostpath"}
-	permissionConfig := mconfig.Config{Name: "FilePermissions", Enabled: "true",
+	permissionConfig := mconfig.Config{Name: "FilePermissions",
 		Data: map[string]string{
 			"mode": "0750",
 		},

--- a/cmd/provisioner-localpv/app/config_test.go
+++ b/cmd/provisioner-localpv/app/config_test.go
@@ -21,7 +21,6 @@ import (
 	"reflect"
 	"testing"
 
-	mconfig "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -67,22 +66,22 @@ func TestGetImagePullSecrets(t *testing.T) {
 }
 
 func TestDataConfigToMap(t *testing.T) {
-	hostpathConfig := mconfig.Config{Name: "StorageType", Value: "hostpath"}
-	xfsQuotaConfig := mconfig.Config{Name: "XFSQuota", Enabled: "true",
-		Data: map[string]string{
+	hostpathConfig := Config{Name: "StorageType", Value: "hostpath"}
+	xfsQuotaConfig := Config{Name: "XFSQuota", Enabled: "true",
+		Data: map[string]RawLiteral{
 			"SoftLimitGrace": "20%",
 			"HardLimitGrace": "80%",
 		},
 	}
 
 	testCases := map[string]struct {
-		config        []mconfig.Config
+		config        []Config
 		expectedValue map[string]interface{}
 	}{
 		"nil 'Data' map": {
-			config: []mconfig.Config{hostpathConfig, xfsQuotaConfig},
+			config: []Config{hostpathConfig, xfsQuotaConfig},
 			expectedValue: map[string]interface{}{
-				"XFSQuota": map[string]string{
+				"XFSQuota": map[string]RawLiteral{
 					"SoftLimitGrace": "20%",
 					"HardLimitGrace": "80%",
 				},
@@ -106,21 +105,21 @@ func TestDataConfigToMap(t *testing.T) {
 }
 
 func TestPermissionConfigToMap(t *testing.T) {
-	hostpathConfig := mconfig.Config{Name: "StorageType", Value: "hostpath"}
-	permissionConfig := mconfig.Config{Name: "FilePermissions",
-		Data: map[string]string{
+	hostpathConfig := Config{Name: "StorageType", Value: "hostpath"}
+	permissionConfig := Config{Name: "FilePermissions",
+		Data: map[string]RawLiteral{
 			"mode": "0750",
 		},
 	}
 
 	testCases := map[string]struct {
-		config        []mconfig.Config
+		config        []Config
 		expectedValue map[string]interface{}
 	}{
 		"nil 'Data' map": {
-			config: []mconfig.Config{hostpathConfig, permissionConfig},
+			config: []Config{hostpathConfig, permissionConfig},
 			expectedValue: map[string]interface{}{
-				"FilePermissions": map[string]string{
+				"FilePermissions": map[string]RawLiteral{
 					"mode": "0750",
 				},
 			},
@@ -144,12 +143,12 @@ func TestPermissionConfigToMap(t *testing.T) {
 
 func Test_listConfigToMap(t *testing.T) {
 	tests := map[string]struct {
-		pvConfig      []mconfig.Config
+		pvConfig      []Config
 		expectedValue map[string]interface{}
 		wantErr       bool
 	}{
 		"Valid list parameter": {
-			pvConfig: []mconfig.Config{
+			pvConfig: []Config{
 				{Name: "StorageType", Value: "hostpath"},
 				{Name: "NodeAffinityLabels", List: []string{"fake-node-label-key"}},
 			},

--- a/cmd/provisioner-localpv/app/provisioner_hostpath.go
+++ b/cmd/provisioner-localpv/app/provisioner_hostpath.go
@@ -63,7 +63,12 @@ func (p *Provisioner) ProvisionHostPath(ctx context.Context, opts pvController.P
 	klog.Infof("Creating volume %v at node with labels {%v}, path:%v,ImagePullSecrets:%v", name, nodeAffinityLabels, path, imagePullSecrets)
 
 	//Before using the path for local PV, make sure it is created.
-	initCmdsForPath := []string{"mkdir", "-m", volumeConfig.GetFsMode(), "-p"}
+        fsMode := volumeConfig.GetFsMode()
+        // Set default value if FilePermissions mode is not specified.
+        if len(fsMode) == 0 {
+                fsMode = "0777"
+        }
+	initCmdsForPath := []string{"mkdir", "-m", fsMode, "-p"}
 	podOpts := &HelperPodOptions{
 		cmdsForPath:        initCmdsForPath,
 		name:               name,

--- a/cmd/provisioner-localpv/app/provisioner_hostpath.go
+++ b/cmd/provisioner-localpv/app/provisioner_hostpath.go
@@ -63,7 +63,7 @@ func (p *Provisioner) ProvisionHostPath(ctx context.Context, opts pvController.P
 	klog.Infof("Creating volume %v at node with labels {%v}, path:%v,ImagePullSecrets:%v", name, nodeAffinityLabels, path, imagePullSecrets)
 
 	//Before using the path for local PV, make sure it is created.
-	initCmdsForPath := []string{"mkdir", "-m", "0777", "-p"}
+	initCmdsForPath := []string{"mkdir", "-m", volumeConfig.GetFsMode(), "-p"}
 	podOpts := &HelperPodOptions{
 		cmdsForPath:        initCmdsForPath,
 		name:               name,

--- a/cmd/provisioner-localpv/app/provisioner_hostpath.go
+++ b/cmd/provisioner-localpv/app/provisioner_hostpath.go
@@ -63,11 +63,11 @@ func (p *Provisioner) ProvisionHostPath(ctx context.Context, opts pvController.P
 	klog.Infof("Creating volume %v at node with labels {%v}, path:%v,ImagePullSecrets:%v", name, nodeAffinityLabels, path, imagePullSecrets)
 
 	//Before using the path for local PV, make sure it is created.
-        fsMode := volumeConfig.GetFsMode()
-        // Set default value if FilePermissions mode is not specified.
-        if len(fsMode) == 0 {
-                fsMode = "0777"
-        }
+	fsMode := volumeConfig.GetFsMode()
+	// Set default value if FilePermissions mode is not specified.
+	if len(fsMode) == 0 {
+		fsMode = "0777"
+	}
 	initCmdsForPath := []string{"mkdir", "-m", fsMode, "-p"}
 	podOpts := &HelperPodOptions{
 		cmdsForPath:        initCmdsForPath,

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -67,7 +67,6 @@ You can provision LocalPV hostpath StorageType volumes dynamically using the def
        #  value: "/var/openebs/local"
        #Use this to set a specific mode for directory creation
        #- name: FilePermissions
-       #  enabled: true
        #  data:
        #     mode: "0770"
   provisioner: openebs.io/local

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -65,6 +65,11 @@ You can provision LocalPV hostpath StorageType volumes dynamically using the def
        # hostpath directory
        #- name: BasePath
        #  value: "/var/openebs/local"
+       #Use this to set a specific mode for directory creation
+       #- name: FilePermissions
+       #  enabled: true
+       #  data:
+       #     mode: "0770"
   provisioner: openebs.io/local
   reclaimPolicy: Delete
   #It is necessary to have volumeBindingMode as WaitForFirstConsumer

--- a/docs/tutorials/hostpath/filepermissions.md
+++ b/docs/tutorials/hostpath/filepermissions.md
@@ -1,0 +1,54 @@
+# File permission tuning
+
+Hostpath LocalPV will by default create folder with the following rights: `0777`. In some usecases, these rights are too wide and should be reduced.
+As an important point, when using hostpath the underlying PV will be a localpath whichs allows kubelet to chown the folder based on the [fsGroup](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods))
+
+We allow to reduce this filepermission using :
+
+```yaml
+  #This is a custom StorageClass template
+  apiVersion: storage.k8s.io/v1
+  kind: StorageClass
+  metadata:
+    name: custom-hostpath
+    annotations:
+      openebs.io/cas-type: local
+      cas.openebs.io/config: |
+        - name: StorageType
+          value: "hostpath"
+        - name: BasePath
+          value: "/var/openebs/local"
+        - name: FilePermissions
+          enabled: true
+          data:
+            mode: "0770"
+  provisioner: openebs.io/local
+  reclaimPolicy: Delete
+  #It is necessary to have volumeBindingMode as WaitForFirstConsumer
+  volumeBindingMode: WaitForFirstConsumer
+```
+
+With such configuration the folder will be crated with `0770` rights for all the PVC using this storage class.
+
+The same configuration is available at PVC level to have a more fined grained configuration capability (overrding the Storage class configuration level):
+
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: localpv-vol
+  annotations:
+    cas.openebs.io/config: |
+      - name: FilePermissions
+        enabled: true
+        data:
+          mode: "0770"
+spec:
+  #Change this name if you are using a custom StorageClass
+  storageClassName: openebs-hostpath
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      #Set capacity here
+      storage: 5Gi
+```

--- a/docs/tutorials/hostpath/filepermissions.md
+++ b/docs/tutorials/hostpath/filepermissions.md
@@ -19,7 +19,6 @@ We allow to set file permissions using:
         - name: BasePath
           value: "/var/openebs/local"
         - name: FilePermissions
-          enabled: true
           data:
             mode: "0770"
   provisioner: openebs.io/local
@@ -40,7 +39,6 @@ metadata:
   annotations:
     cas.openebs.io/config: |
       - name: FilePermissions
-        enabled: true
         data:
           mode: "0770"
 spec:

--- a/docs/tutorials/hostpath/filepermissions.md
+++ b/docs/tutorials/hostpath/filepermissions.md
@@ -3,7 +3,7 @@
 Hostpath LocalPV will by default create folder with the following rights: `0777`. In some usecases, these rights are too wide and should be reduced.
 As an important point, when using hostpath the underlying PV will be a localpath whichs allows kubelet to chown the folder based on the [fsGroup](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods))
 
-We allow to set file permissions using:  
+We allow to set file permissions using:
 
 ```yaml
   #This is a custom StorageClass template
@@ -30,7 +30,7 @@ We allow to set file permissions using:
 
 With such configuration the folder will be crated with `0770` rights for all the PVC using this storage class.
 
-The same configuration is available at PVC level to have a more fined grained configuration capability (overrding the Storage class configuration level):
+The same configuration is available at PVC level to have a more fined grained configuration capability (the Storage class configuration will always win against PVC one):
 
 ```yaml
 kind: PersistentVolumeClaim

--- a/docs/tutorials/hostpath/filepermissions.md
+++ b/docs/tutorials/hostpath/filepermissions.md
@@ -3,7 +3,7 @@
 Hostpath LocalPV will by default create folder with the following rights: `0777`. In some usecases, these rights are too wide and should be reduced.
 As an important point, when using hostpath the underlying PV will be a localpath whichs allows kubelet to chown the folder based on the [fsGroup](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods))
 
-We allow to reduce this filepermission using :
+We allow to set file permissions using:  
 
 ```yaml
   #This is a custom StorageClass template


### PR DESCRIPTION
From https://github.com/openebs/dynamic-localpv-provisioner/pull/157, by @sushiMix:
> ## Pull Request template
> 
> **Why is this PR required? What issue does it fix?**:
> Fixes https://github.com/openebs/dynamic-localpv-provisioner/issues/95.
> 
> **What this PR does?**:
> It allows to configure default directory mode using LocaMode entry in cas.openebs.io/config.
> 
> **Does this PR require any upgrade changes?**: No
> 
> **If the changes in this PR are manually verified, list down the scenarios covered:**:
> 
> ```
> apiVersion: storage.k8s.io/v1
> kind: StorageClass
> metadata:
>   annotations:
>     cas.openebs.io/config: |
>       - name: StorageType
>         value: "hostpath"
>       - name: BasePath
>         value: "/opt/data/"
>       - name: FilePermissions
>         data:
>           mode: "770"
>     openebs.io/cas-type: local
>   name: local-path
> provisioner: openebs.io/local
> reclaimPolicy: Delete
> volumeBindingMode: WaitForFirstConsumer
> ---
> apiVersion: v1
> kind: PersistentVolumeClaim
> metadata:
>   name: task-pv-claim
> spec:
>   storageClassName: local-path
>   accessModes:
>     - ReadWriteOnce
>   resources:
>     requests:
>       storage: 1Gi
> ---
> apiVersion: v1
> kind: Pod
> metadata:
>   name: task-pv-pod
> spec:
>   volumes:
>     - name: task-pv-storage
>       persistentVolumeClaim:
>         claimName: task-pv-claim
>   containers:
>     - name: task-pv-container
>       image: nginx
>       ports:
>         - containerPort: 80
>           name: "http-server"
>       volumeMounts:
>         - mountPath: "/usr/share/nginx/html"
>           name: task-pv-storage
> ```
> 
> check the file mode of the created folder (0770 instead of 0777)
> 
> **Any additional information for your reviewer?** : 
> _Mention if this PR is part of any design or a continuation of previous PRs_
> 
> 
> **Checklist:**
> - [x] Fixes #95
> - [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
> - [ ] Has the change log section been updated? 
> - [] Commit has unit tests
> - [] Commit has integration tests
> - [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
> - [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
> 
> **PLEASE REMOVE BELOW INFORMATION BEFORE SUBMITTING**
> 
> IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.