### PR TITLE
feat(provisioner): add support for warning log de-duplication

### DIFF
--- a/changelogs/unreleased/282-niladrih
+++ b/changelogs/unreleased/282-niladrih
@@ -1,0 +1,1 @@
+Add support for warning log de-duplication

--- a/cmd/provisioner-localpv/app/start.go
+++ b/cmd/provisioner-localpv/app/start.go
@@ -12,8 +12,11 @@ import (
 	"github.com/openebs/maya/pkg/version"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	pvController "sigs.k8s.io/sig-storage-lib-external-provisioner/v9/controller"
+
+	"github.com/openebs/dynamic-localpv-provisioner/pkg/logger"
 )
 
 var (
@@ -23,6 +26,7 @@ var (
 	// localpv provisioner
 	LeaderElectionKey = "LEADER_ELECTION_ENABLED"
 	usage             = cmdName
+	dedupeWarnings    bool
 )
 
 // StartProvisioner will start a new dynamic Host Path PV provisioner
@@ -39,6 +43,8 @@ func StartProvisioner() (*cobra.Command, error) {
 		},
 	}
 
+	cmd.PersistentFlags().BoolVar(&dedupeWarnings, "dedupe-warnings", false, "De-duplicate warning messages")
+
 	return cmd, nil
 }
 
@@ -46,6 +52,15 @@ func StartProvisioner() (*cobra.Command, error) {
 func Start(cmd *cobra.Command) error {
 	klog.Infof("Starting Provisioner...")
 
+	// De-duplicate warning messages, to avoid flooding logs.
+	if dedupeWarnings {
+		rest.SetDefaultWarningHandler(
+			rest.NewWarningWriter(logger.KlogWarner{}, rest.WarningWriterOptions{
+				Deduplicate: true,
+				Color:       false,
+			}),
+		)
+	}
 	// Dynamic Provisioner can run successfully if it can establish
 	// connection to the Kubernetes Cluster. mKube helps with
 	// establishing the connection either via InCluster or

--- a/cmd/provisioner-localpv/main.go
+++ b/cmd/provisioner-localpv/main.go
@@ -67,6 +67,7 @@ func run() error {
 
 	// Merge all flags from the Cobra Command to the global FlagSet
 	// and Parse them
+	pflag.CommandLine.AddFlagSet(cmd.PersistentFlags())
 	pflag.CommandLine.AddFlagSet(cmd.Flags())
 	pflag.Parse()
 

--- a/deploy/helm/charts/templates/deployment.yaml
+++ b/deploy/helm/charts/templates/deployment.yaml
@@ -50,6 +50,16 @@ spec:
       - name: {{ template "localpv.fullname" . }}
         image: "{{ with .Values.localpv.image.registry | default .Values.global.imageRegistry | trimSuffix "/" }}{{ . }}/{{ end }}{{ .Values.localpv.image.repository }}:{{ .Values.localpv.image.tag }}"
         imagePullPolicy: {{ .Values.localpv.image.pullPolicy }}
+        {{- $args := list }}
+        {{- if .Values.localpv.logging.dedupeWarnings }}
+          {{- $args = append $args "--dedupe-warnings" }}
+        {{- end }}
+        {{- if gt (len $args) 0 }}
+        args:
+        {{- range $args }}
+        - {{ . | quote }}
+        {{- end }}
+        {{- end }}
         resources:
 {{ toYaml .Values.localpv.resources | indent 10 }}
         env:

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -40,6 +40,9 @@ localpv:
     ## Labels to be added to localpv provisioner deployment pods
   podLabels:
     name: openebs-localpv-provisioner
+  logging:
+    # Disable duplicate warning messages
+    dedupeWarnings: false
   healthCheck:
     initialDelaySeconds: 30
     periodSeconds: 60

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -35,10 +35,19 @@ var (
 	loggerKillSwitch     = make(chan struct{})
 )
 
+// KlogWriter writes to Klog's Info stream.
 type KlogWriter struct{}
 
 func (k KlogWriter) Write(data []byte) (n int, err error) {
 	klog.Info(string(data))
+	return len(data), nil
+}
+
+// KlogWarner writes to Klog's Warning stream.
+type KlogWarner struct{}
+
+func (w KlogWarner) Write(data []byte) (n int, err error) {
+	klog.Warning(string(data))
 	return len(data), nil
 }
 


### PR DESCRIPTION
## Pull Request template

**Why is this PR required? What issue does it fix?**:
Fixes #279

**What this PR does?**:
This change adds a custom Warning logger to the kubernetes REST client, so that warning logs are duplicated and they don't flood the logs.
Adds a CLI flag `--dedupe-warnings` to enable this option.
Adds a helm chart value `localpv.logging.dedupeWarnings=true` to use the above flag.

**Does this PR require any upgrade changes?**:
Nope

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Verified in kubernetes v1.33.0 (minikube) that there is indeed a flood of warnings related to the use of Endpoints instead of EndpointSlices. Used the flag with the helm chart and verified that a single log is present the next time round.

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 


**PLEASE REMOVE BELOW INFORMATION BEFORE SUBMITTING**

The PR title message must follow convention:
   `<type>(<scope>): <subject>`.

Where:
    Most common types are:
    * `feat`        - for new features, not a new feature for build script
    * `fix`         - for bug fixes or improvements, not a fix for build script
    * `chore`       - changes not related to production code
    * `docs`        - changes related to documentation
    * `style`       - formatting, missing semi colons, linting fix etc; no significant production code changes
    * `test`        - adding missing tests, refactoring tests; no production code change
    * `refactor`    - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes
    * `cherry-pick` - if PR is merged in master branch and raised to release branch(like v0.4.x)
    
IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
