### PR TITLE
Update deployment.yaml

### DIFF
--- a/deploy/helm/charts/templates/deployment.yaml
+++ b/deploy/helm/charts/templates/deployment.yaml
@@ -4,6 +4,7 @@ kind: Deployment
 metadata:
   name: {{ template "localpv.fullname" . }}
   {{- with .Values.localpv.annotations }}
+  namespace: {{ .Release.Namespace }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
   labels:


### PR DESCRIPTION
We need deployments have their specific namespaces.

 if you run commands:
helm show values openebs/openebs > values.yaml
helm template openebs openebs/openebs --namespace openebs -f values.yaml > openebs-generated-values.yaml

You see many blocks (for example this Deployment block) does not have namespace: openebs
