### PR TITLE
Add Node-Deployment Mode for High-Performance LocalPV Provisioning

### DIFF
--- a/buildscripts/provisioner-localpv/Dockerfile
+++ b/buildscripts/provisioner-localpv/Dockerfile
@@ -22,7 +22,14 @@ RUN apk add --no-cache \
     mii-tool \
     procps \
     libc6-compat \
-    ca-certificates
+    ca-certificates \
+    util-linux \
+    e2fsprogs \
+    xfsprogs \
+    xfsprogs-extra \
+    blkid \
+    findmnt \
+    quota-tools
 
 COPY provisioner-localpv /
 

--- a/buildscripts/provisioner-localpv/provisioner-localpv.Dockerfile
+++ b/buildscripts/provisioner-localpv/provisioner-localpv.Dockerfile
@@ -60,7 +60,14 @@ RUN apk add --no-cache \
     curl \
     net-tools \
     procps \
-    ca-certificates
+    ca-certificates \
+    util-linux \
+    e2fsprogs \
+    xfsprogs \
+    xfsprogs-extra \
+    blkid \
+    findmnt \
+    quota-tools
 
 COPY --from=build /go/src/github.com/openebs/dynamic-localpv-provisioner/bin/provisioner-localpv/provisioner-localpv /usr/local/bin/provisioner-localpv
 

--- a/cmd/provisioner-localpv/app/config.go
+++ b/cmd/provisioner-localpv/app/config.go
@@ -2,9 +2,10 @@ package app
 
 import (
 	"context"
-	"gopkg.in/yaml.v3"
 	"strconv"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 
 	mconfig "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	hostpath "github.com/openebs/maya/pkg/hostpath/v1alpha1"
@@ -146,6 +147,9 @@ func (p *Provisioner) GetVolumeConfig(ctx context.Context, pvName string, pvc *c
 
 	//Fetch the SC
 	scName := GetStorageClassName(pvc)
+	if scName == nil || *scName == "" {
+		return nil, errors.Errorf("failed to get storageclass: storageClassName is not set in PVC %s/%s", pvc.Namespace, pvc.Name)
+	}
 	sc, err := p.kubeClient.StorageV1().StorageClasses().Get(ctx, *scName, metav1.GetOptions{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get storageclass: missing sc name {%v}", scName)

--- a/cmd/provisioner-localpv/app/env.go
+++ b/cmd/provisioner-localpv/app/env.go
@@ -59,3 +59,13 @@ func getOpenEBSServiceAccountName() string {
 func getOpenEBSImagePullSecrets() string {
 	return menv.Get(ProvisionerImagePullSecrets)
 }
+
+// getNodeName returns the current node name from NODE_NAME environment variable
+func getNodeName() string {
+	return menv.Get(menv.ENVKey("NODE_NAME"))
+}
+
+// GetEnv gets an environment variable value
+func GetEnv(key string) string {
+	return menv.Get(menv.ENVKey(key))
+}

--- a/cmd/provisioner-localpv/app/helper_hostpath.go
+++ b/cmd/provisioner-localpv/app/helper_hostpath.go
@@ -213,7 +213,28 @@ func (p *Provisioner) createCleanupPod(ctx context.Context, pOpts *HelperPodOpti
 
 	config.taints = pOpts.selectedNodeTaints
 
-	config.pOpts.cmdsForPath = append(config.pOpts.cmdsForPath, filepath.Join("/data/", config.volumeDir))
+	// check if path is xfs quota enabled and remove quota projid
+	// FS stores the file system of mount
+	fsType := "FS=`stat -f -c %T /data` ; "
+	// volumePath is the full path to the volume directory
+	volumePath := filepath.Join("/data/", config.volumeDir)
+	// cleanupScript checks fs type and removes quota before deleting directory
+	cleanupScript := "" +
+		"if [[ \"$FS\" == \"xfs\" ]]; then " +
+		"  ID=`xfs_io -c stat " + volumePath + " 2>/dev/null | awk '/projid/{print $3}' | head -1` ;" +
+		"  echo \"projid=$ID\" ;" +
+		"  if [ -n \"$ID\" ] && [ \"$ID\" != \"0\" ]; then " +
+		"    xfs_io -c 'chproj -R 0' " + volumePath + " 2>/dev/null || true ;" +
+		"    xfs_quota -x -c 'limit -p bsoft=0 bhard=0 '$ID /data 2>/dev/null || true ;" +
+		"  fi ;" +
+		"elif [[ \"$FS\" == \"ext2/ext3\" ]]; then " +
+		"  ID=`lsattr -pd " + volumePath + "/ | awk '{print $1}'` ;" +
+		"  if [ -n \"$ID\" ] && [ \"$ID\" != \"0\" ]; then " +
+		"    setquota -P $ID 0 0 0 0 /data 2>/dev/null || true ;" +
+		"  fi ;" +
+		"fi ; " +
+		"rm -rf " + volumePath
+	config.pOpts.cmdsForPath = []string{"sh", "-c", fsType + cleanupScript}
 
 	_, err := p.launchPod(ctx, config)
 	if err != nil && !k8serror.IsAlreadyExists(err) {

--- a/cmd/provisioner-localpv/app/helper_volume_manager.go
+++ b/cmd/provisioner-localpv/app/helper_volume_manager.go
@@ -1,0 +1,41 @@
+package app
+
+import (
+	"context"
+
+	"k8s.io/klog/v2"
+)
+
+// createVolumeLocally performs volume creation directly on the local node
+func (p *Provisioner) createVolumeLocally(ctx context.Context, pOpts *HelperPodOptions, enableQuota bool) error {
+	klog.Infof("Creating volume %s locally", pOpts.name)
+
+	// Create a temporary volume manager to perform local operations
+	vm := NewLocalVolumeManager()
+
+	req := &VolumeRequest{
+		Name:           pOpts.name,
+		Path:           pOpts.path,
+		FsMode:         "0777", // Default file permissions
+		SoftLimitGrace: pOpts.softLimitGrace,
+		HardLimitGrace: pOpts.hardLimitGrace,
+		PVCStorage:     pOpts.pvcStorage,
+	}
+
+	return vm.CreateVolume(ctx, req, enableQuota)
+}
+
+// deleteVolumeLocally deletes volume directly on the local node
+func (p *Provisioner) deleteVolumeLocally(ctx context.Context, pOpts *HelperPodOptions) error {
+	klog.Infof("Deleting volume %s locally", pOpts.name)
+
+	// Create a temporary volume manager to perform local operations
+	vm := NewLocalVolumeManager()
+
+	req := &VolumeRequest{
+		Name: pOpts.name,
+		Path: pOpts.path,
+	}
+
+	return vm.DeleteVolume(ctx, req)
+}

--- a/cmd/provisioner-localpv/app/local_volume_manager.go
+++ b/cmd/provisioner-localpv/app/local_volume_manager.go
@@ -1,0 +1,314 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	hostpath "github.com/openebs/maya/pkg/hostpath/v1alpha1"
+	"k8s.io/klog/v2"
+)
+
+// VolumeRequest represents a request for volume operations
+type VolumeRequest struct {
+	Name           string `json:"name"`
+	Path           string `json:"path"`
+	FsMode         string `json:"fsMode,omitempty"`
+	SoftLimitGrace string `json:"softLimitGrace,omitempty"`
+	HardLimitGrace string `json:"hardLimitGrace,omitempty"`
+	PVCStorage     int64  `json:"pvcStorage,omitempty"`
+}
+
+// LocalVolumeManager handles volume operations on the local node
+type LocalVolumeManager struct {
+	// Add any necessary fields for volume management
+
+	// race condition protection
+	// mutex for thread-safe operations
+	mu *sync.Mutex
+}
+
+// NewLocalVolumeManager creates a new LocalVolumeManager instance
+func NewLocalVolumeManager() *LocalVolumeManager {
+	return &LocalVolumeManager{
+		mu: &sync.Mutex{},
+	}
+}
+
+// CreateVolume creates a new volume directory on the local node
+func (vm *LocalVolumeManager) CreateVolume(ctx context.Context, req *VolumeRequest, enableQuota bool) error {
+	vm.mu.Lock()
+	defer vm.mu.Unlock()
+	klog.Infof("Creating volume %s at path %s", req.Name, req.Path)
+
+	// Extract the base path and the volume unique path
+	parentDir, volumeDir, err := ExtractPaths(req.Path)
+	if err != nil {
+		return fmt.Errorf("failed to extract paths: %v", err)
+	}
+
+	// Set default file permissions if not specified
+	fsMode := req.FsMode
+	if fsMode == "" {
+		fsMode = "0777"
+	}
+
+	// Create the directory with specified permissions
+	fullPath := filepath.Join(parentDir, volumeDir)
+	if err := vm.executeCommand(ctx, "mkdir", "-m", fsMode, "-p", fullPath); err != nil {
+		return fmt.Errorf("failed to create directory: %v", err)
+	}
+
+	if enableQuota {
+		// Apply quota if enabled
+		if err := vm.ApplyQuota(ctx, req); err != nil {
+			return fmt.Errorf("failed to apply quota: %v", err)
+		}
+	}
+
+	klog.Infof("Successfully created volume %s at path %s", req.Name, fullPath)
+	return nil
+}
+
+// DeleteVolume removes a volume directory from the local node
+func (vm *LocalVolumeManager) DeleteVolume(ctx context.Context, req *VolumeRequest) error {
+	vm.mu.Lock()
+	defer vm.mu.Unlock()
+	klog.Infof("Deleting volume %s at path %s", req.Name, req.Path)
+
+	// Extract the base path and the volume unique path
+	parentDir, volumeDir, err := ExtractPaths(req.Path)
+	if err != nil {
+		return fmt.Errorf("failed to extract paths: %v", err)
+	}
+
+	// Remove the directory
+	fullPath := filepath.Join(parentDir, volumeDir)
+
+	// check if path is xfs quota enabled and remove quota projid
+	cleanupCmdsForPath := fmt.Sprintf(`
+        d="%s"
+        base="%s"
+        # check fs type first
+        fs=$(stat -f -c %%T $base 2>/dev/null)
+        if [ "$fs" = "xfs" ]; then
+			id=$(xfs_io -c stat $d 2>/dev/null | awk '/projid/{print $3}' | head -1)
+			echo "projid=$id"
+			if [ -n "$id" ] && [ "$id" != "0" ]; then
+				# remove projid binding
+				xfs_io -c "chproj -R 0" "$d" 2>/dev/null || true
+				# remove quota limit
+				xfs_quota -x -c "limit -p bsoft=0 bhard=0 $id" $base 2>/dev/null || true
+			fi
+        elif [ "$fs" = "ext2/ext3" ]; then
+			ID=$(lsattr -pd $d/ | awk '{print $1}')
+			if [ -n "$ID" ] && [ "$ID" != "0" ]; then
+				setquota -P $ID 0 0 0 0 $base 2>/dev/null || true
+			fi
+		fi
+		rm -rf $d
+	`, fullPath, parentDir)
+
+	if err := vm.executeCommand(ctx, "sh", "-c", cleanupCmdsForPath); err != nil {
+		return fmt.Errorf("failed to delete directory: %v", err)
+	}
+
+	klog.Infof("Successfully deleted volume %s at path %s", req.Name, fullPath)
+	return nil
+}
+
+// ApplyQuota applies filesystem quota to a volume
+func (vm *LocalVolumeManager) ApplyQuota(ctx context.Context, req *VolumeRequest) error {
+	klog.Infof("Applying quota for volume %s at path %s", req.Name, req.Path)
+
+	// Extract the base path and the volume unique path
+	parentDir, volumeDir, err := ExtractPaths(req.Path)
+	if err != nil {
+		return fmt.Errorf("failed to extract paths: %v", err)
+	}
+
+	// Convert limits to kilobytes
+	softLimitGrace, err := vm.convertToK(req.SoftLimitGrace, req.PVCStorage)
+	if err != nil {
+		return fmt.Errorf("failed to convert soft limit: %v", err)
+	}
+
+	hardLimitGrace, err := vm.convertToK(req.HardLimitGrace, req.PVCStorage)
+	if err != nil {
+		return fmt.Errorf("failed to convert hard limit: %v", err)
+	}
+
+	// Validate limits
+	if err := vm.validateLimits(softLimitGrace, hardLimitGrace, req.PVCStorage); err != nil {
+		return fmt.Errorf("invalid limits: %v", err)
+	}
+
+	// Apply quota based on filesystem type
+	if err := vm.applyQuotaByFilesystem(ctx, parentDir, volumeDir, softLimitGrace, hardLimitGrace); err != nil {
+		return fmt.Errorf("failed to apply quota: %v", err)
+	}
+
+	klog.Infof("Successfully applied quota for volume %s", req.Name)
+	return nil
+}
+
+// extractPaths extracts parent directory and volume directory from the full path
+func ExtractPaths(fullPath string) (parentDir, volumeDir string, err error) {
+	// Use hostpath builder to validate and extract paths
+	return hostpath.NewBuilder().WithPath(fullPath).
+		WithCheckf(hostpath.IsNonRoot(), "volume directory {%v} should not be under root directory", fullPath).
+		ExtractSubPath()
+}
+
+// executeCommand executes a system command with timeout
+func (vm *LocalVolumeManager) executeCommand(ctx context.Context, name string, args ...string) error {
+	// Create command context with timeout
+	cmdCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(cmdCtx, name, args...)
+
+	// Run the command
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		outputStr := string(output)
+		if exitError, ok := err.(*exec.ExitError); ok {
+			if status, ok := exitError.Sys().(syscall.WaitStatus); ok {
+				// Check for specific error conditions
+				switch status.ExitStatus() {
+				case 127: // Command not found
+					return fmt.Errorf("command not found: %s - please ensure required quota tools are installed", name)
+				case 1: // General error
+					if strings.Contains(outputStr, "Unsupported filesystem type") {
+						return fmt.Errorf("unsupported filesystem type - please ensure the filesystem supports quotas and is properly mounted with quota options")
+					}
+					return fmt.Errorf("command failed with exit code %d: %s", status.ExitStatus(), outputStr)
+				default:
+					return fmt.Errorf("command failed with exit code %d: %s", status.ExitStatus(), outputStr)
+				}
+			}
+		}
+		return fmt.Errorf("command failed: %v, output: %s", err, outputStr)
+	}
+
+	return nil
+}
+
+// convertToK converts the limits to kilobytes
+func (vm *LocalVolumeManager) convertToK(limit string, pvcStorage int64) (string, error) {
+	if len(limit) == 0 {
+		return "0k", nil
+	}
+
+	valueRegex := regexp.MustCompile(`[\d]*[\.]?[\d]*`)
+	valueString := valueRegex.FindString(limit)
+
+	if limit != valueString+"%" {
+		return "", fmt.Errorf("invalid format for limit grace")
+	}
+
+	value, err := strconv.ParseFloat(valueString, 64)
+	if err != nil {
+		return "", fmt.Errorf("invalid format, cannot parse")
+	}
+
+	if value > 100 {
+		value = 100
+	}
+
+	value *= float64(pvcStorage)
+	value /= 100
+	value += float64(pvcStorage)
+	value /= 1024
+
+	value = math.Ceil(value)
+	valueString = strconv.FormatFloat(value, 'f', -1, 64)
+	valueString += "k"
+	return valueString, nil
+}
+
+// validateLimits validates quota limits
+func (vm *LocalVolumeManager) validateLimits(softLimitGrace, hardLimitGrace string, pvcStorage int64) error {
+	if softLimitGrace == "0k" && hardLimitGrace == "0k" {
+		// Use PVC storage as both limits
+		pvcStorageInK := math.Ceil(float64(pvcStorage) / 1024)
+		pvcStorageInKString := strconv.FormatFloat(pvcStorageInK, 'f', -1, 64) + "k"
+		softLimitGrace = pvcStorageInKString
+		hardLimitGrace = pvcStorageInKString
+		return nil
+	}
+
+	if softLimitGrace == "0k" || hardLimitGrace == "0k" {
+		return nil
+	}
+
+	if len(softLimitGrace) > len(hardLimitGrace) ||
+		(len(softLimitGrace) == len(hardLimitGrace) && softLimitGrace > hardLimitGrace) {
+		return fmt.Errorf("hard limit cannot be smaller than soft limit")
+	}
+
+	return nil
+}
+
+// applyQuotaByFilesystem applies quota based on the filesystem type
+func (vm *LocalVolumeManager) applyQuotaByFilesystem(ctx context.Context, parentDir, volumeDir, softLimitGrace, hardLimitGrace string) error {
+	// Create a shell script to detect filesystem and apply quota
+	// We need to find the actual XFS mount point since parentDir might be a bind mount
+
+	// Extract numeric values for EXT4 setquota (it expects plain numbers in KB blocks, not with suffix)
+	extSoftLimit := strings.TrimSuffix(softLimitGrace, "k")
+	extHardLimit := strings.TrimSuffix(hardLimitGrace, "k")
+
+	script := fmt.Sprintf(`
+		set -e
+		
+		# Find the actual mount point for the path using host's mount info
+		# The host's proc is mounted at /host/proc for container environments
+		if [ -f /host/proc/1/mountinfo ]; then
+			# Use host's mountinfo to find the real mount point
+			MOUNT_POINT=$(findmnt -n -o TARGET --target %s --mountinfo /host/proc/1/mountinfo 2>/dev/null || findmnt -n -o TARGET --target %s 2>/dev/null || echo %s)
+		else
+			MOUNT_POINT=$(findmnt -n -o TARGET --target %s 2>/dev/null || echo %s)
+		fi
+		
+		# Get filesystem type
+		FS=$(stat -f -c %%T %s)
+		
+		if [[ "$FS" == "xfs" ]]; then
+			# Get the next available project ID
+			PID=$(xfs_quota -x -c 'report -h' "$MOUNT_POINT" 2>/dev/null | tail -2 | awk 'NR==1{print substr ($1,2)}+0' || echo "0")
+			PID=$((PID + 1))
+			# Set up project for the volume directory
+			xfs_quota -x -c "project -s -p %s $PID" "$MOUNT_POINT"
+			# Apply quota limits
+			xfs_quota -x -c "limit -p bsoft=%s bhard=%s $PID" "$MOUNT_POINT"
+		elif [[ "$FS" == "ext2/ext3" ]]; then
+			PID=$(repquota -P "$MOUNT_POINT" 2>/dev/null | tail -3 | awk 'NR==1{print substr ($1,2)}+0' || echo "0")
+			PID=$((PID + 1))
+			chattr +P -p $PID %s
+			# setquota -P expects block limits as plain numbers (in KB blocks)
+			setquota -P $PID %s %s 0 0 "$MOUNT_POINT"
+		else
+			echo "Unsupported filesystem type: $FS"
+			exit 1
+		fi`,
+		parentDir, parentDir, parentDir, // findmnt with host mountinfo, fallback, and default
+		parentDir, parentDir, // findmnt without host mountinfo
+		parentDir,                           // stat filesystem
+		filepath.Join(parentDir, volumeDir), // project path
+		softLimitGrace, hardLimitGrace,      // xfs limits (with 'k' suffix)
+		filepath.Join(parentDir, volumeDir), // chattr path
+		extSoftLimit, extHardLimit,          // ext quota limits (plain numbers in KB)
+	)
+
+	// Execute the quota script
+	return vm.executeCommand(ctx, "sh", "-c", script)
+}

--- a/cmd/provisioner-localpv/app/provisioner.go
+++ b/cmd/provisioner-localpv/app/provisioner.go
@@ -1,18 +1,3 @@
-/*
-This file contains the volume creation and deletion handlers invoked by
-the github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller.
-
-The handler that are madatory to be implemented:
-
-- Provision - is called by controller to perform custom validation on the PVC
-  request and return a valid PV spec. The controller will create the PV object
-  using the spec passed to it and bind it to the PVC.
-
-- Delete - is called by controller to perform cleanup tasks on the PV before
-  deleting it.
-
-*/
-
 package app
 
 import (
@@ -104,6 +89,29 @@ func (p *Provisioner) Provision(ctx context.Context, opts pvController.Provision
 		return nil, pvController.ProvisioningFinished, fmt.Errorf("configuration error, node{%v} hostname is empty", opts.SelectedNode.Name)
 	}
 
+	// In node-deployment mode, only process PVCs scheduled to this node.
+	// This prevents multiple provisioner instances from trying to provision the same PVC.
+	if p.nodeDeployment {
+		// Use the hostname label for consistency with Delete() and node affinity settings
+		selectedNodeHostname := GetNodeHostname(opts.SelectedNode)
+		if selectedNodeHostname == "" {
+			// Fallback to node name if hostname label is not present
+			selectedNodeHostname = opts.SelectedNode.Name
+		}
+		if selectedNodeHostname != p.nodeName {
+			// This PVC is scheduled to a different node, skip it.
+			// Return IgnoredError to tell the controller that this provisioner
+			// is not responsible for this PVC. The controller will not treat
+			// this as a failure and will let another provisioner handle it.
+			klog.V(4).Infof("Skipping PVC %s/%s: scheduled to node %s, but this provisioner is on node %s",
+				pvc.Namespace, pvc.Name, selectedNodeHostname, p.nodeName)
+			return nil, pvController.ProvisioningFinished, &pvController.IgnoredError{
+				Reason: fmt.Sprintf("PVC is scheduled to node %s, not this node %s", selectedNodeHostname, p.nodeName),
+			}
+		}
+		klog.Infof("Processing PVC %s/%s on local node %s", pvc.Namespace, pvc.Name, p.nodeName)
+	}
+
 	name := opts.PVName
 
 	// Create a new Config instance for the PV by merging the
@@ -126,7 +134,8 @@ func (p *Provisioner) Provision(ctx context.Context, opts pvController.Provision
 	// todo: Disable the localpv device provisioning for now. Revisit later to remove the code path.
 
 	// EXCEPTION: Block VolumeMode
-	if *opts.PVC.Spec.VolumeMode == v1.PersistentVolumeBlock && stgType != "device" {
+	// VolumeMode is a pointer and can be nil (defaults to Filesystem)
+	if opts.PVC.Spec.VolumeMode != nil && *opts.PVC.Spec.VolumeMode == v1.PersistentVolumeBlock && stgType != "device" {
 		return nil, pvController.ProvisioningFinished, fmt.Errorf("PV with BlockMode is not supported with StorageType %v", stgType)
 	}
 
@@ -150,9 +159,45 @@ func (p *Provisioner) Provision(ctx context.Context, opts pvController.Provision
 //	set to not-retain, then this function will create a helper pod
 //	to delete the host path from the node.
 func (p *Provisioner) Delete(ctx context.Context, pv *v1.PersistentVolume) (err error) {
+	// In node-deployment mode, only process PVs that are on this node
+	if p.nodeDeployment {
+		// Get the node affinity from the PV
+		if pv.Spec.NodeAffinity != nil && pv.Spec.NodeAffinity.Required != nil {
+			isLocalNode := false
+			var pvNodeName string
+			for _, term := range pv.Spec.NodeAffinity.Required.NodeSelectorTerms {
+				for _, expr := range term.MatchExpressions {
+					if expr.Key == "kubernetes.io/hostname" && expr.Operator == v1.NodeSelectorOpIn {
+						for _, value := range expr.Values {
+							pvNodeName = value
+							if value == p.nodeName {
+								isLocalNode = true
+								break
+							}
+						}
+					}
+				}
+			}
+			if !isLocalNode {
+				// Return IgnoredError to tell the controller that this provisioner
+				// is not responsible for this PV. The controller will not treat
+				// this as a failure and will let another provisioner handle it.
+				klog.V(4).Infof("Skipping PV %s deletion: belongs to node %s, not this node %s", pv.Name, pvNodeName, p.nodeName)
+				return &pvController.IgnoredError{
+					Reason: fmt.Sprintf("PV belongs to node %s, not this node %s", pvNodeName, p.nodeName),
+				}
+			}
+			klog.Infof("Processing PV %s deletion on local node %s", pv.Name, p.nodeName)
+		}
+	}
+
+	// Use defer for error wrapping only after node filtering
 	defer func() {
-		err = errors.Wrapf(err, "failed to delete volume %v", pv.Name)
+		if err != nil {
+			err = errors.Wrapf(err, "failed to delete volume %v", pv.Name)
+		}
 	}()
+
 	//Initiate clean up only when reclaim policy is not retain.
 	if pv.Spec.PersistentVolumeReclaimPolicy != v1.PersistentVolumeReclaimRetain {
 		//TODO: Determine the type of PV

--- a/cmd/provisioner-localpv/app/provisioner_hostpath.go
+++ b/cmd/provisioner-localpv/app/provisioner_hostpath.go
@@ -79,7 +79,53 @@ func (p *Provisioner) ProvisionHostPath(ctx context.Context, opts pvController.P
 		imagePullSecrets:   imagePullSecrets,
 		hostNetwork:        hostNetwork,
 	}
-	iErr := p.createInitPod(ctx, podOpts)
+
+	var (
+		softLimitGrace string
+		hardLimitGrace string
+		pvcStorage     int64
+		enableQuota    bool = false
+	)
+
+	if volumeConfig.IsXfsQuotaEnabled() || volumeConfig.IsExt4QuotaEnabled() {
+		enableQuota = true
+	}
+
+	if enableQuota {
+		// Read quota parameters from the correct key based on which quota type is enabled
+		quotaKey := KeyXFSQuota
+		if volumeConfig.IsExt4QuotaEnabled() {
+			quotaKey = KeyEXT4Quota
+		}
+		softLimitGrace = volumeConfig.getDataField(quotaKey, KeyQuotaSoftLimit)
+		hardLimitGrace = volumeConfig.getDataField(quotaKey, KeyQuotaHardLimit)
+		pvcStorage = opts.PVC.Spec.Resources.Requests.Storage().Value()
+		podOpts = &HelperPodOptions{
+			cmdsForPath:        initCmdsForPath,
+			name:               name,
+			path:               path,
+			nodeAffinityLabels: nodeAffinityLabels,
+			serviceAccountName: saName,
+			selectedNodeTaints: taints,
+			imagePullSecrets:   imagePullSecrets,
+			softLimitGrace:     softLimitGrace,
+			hardLimitGrace:     hardLimitGrace,
+			pvcStorage:         pvcStorage,
+			hostNetwork:        hostNetwork,
+		}
+	}
+
+	// In node deployment mode, use local operations directly
+	// Otherwise, fallback to helper pods
+
+	// By calling the method of creating and initializing a Pod,
+	// multiple different operations will occur and there will be asynchronous operation problems.
+	// It is recommended to abandon this method
+	var iErr error
+	if !p.nodeDeployment {
+		iErr = p.createInitPod(ctx, podOpts)
+	}
+
 	if iErr != nil {
 		klog.Infof("Initialize volume %v failed: %v", name, iErr)
 		alertlog.Logger.Errorw("",
@@ -92,24 +138,9 @@ func (p *Provisioner) ProvisionHostPath(ctx context.Context, opts pvController.P
 		return nil, pvController.ProvisioningFinished, iErr
 	}
 
-	if volumeConfig.IsXfsQuotaEnabled() {
-		softLimitGrace := volumeConfig.getDataField(KeyXFSQuota, KeyQuotaSoftLimit)
-		hardLimitGrace := volumeConfig.getDataField(KeyXFSQuota, KeyQuotaHardLimit)
-		pvcStorage := opts.PVC.Spec.Resources.Requests.Storage().Value()
-
-		podOpts := &HelperPodOptions{
-			name:               name,
-			path:               path,
-			nodeAffinityLabels: nodeAffinityLabels,
-			serviceAccountName: saName,
-			selectedNodeTaints: taints,
-			imagePullSecrets:   imagePullSecrets,
-			softLimitGrace:     softLimitGrace,
-			hardLimitGrace:     hardLimitGrace,
-			pvcStorage:         pvcStorage,
-			hostNetwork:        hostNetwork,
-		}
-		iErr := p.createQuotaPod(ctx, podOpts)
+	if enableQuota && !p.nodeDeployment {
+		var iErr error
+		iErr = p.createQuotaPod(ctx, podOpts)
 		if iErr != nil {
 			klog.Infof("Applying quota failed: %v", iErr)
 			alertlog.Logger.Errorw("",
@@ -129,41 +160,20 @@ func (p *Provisioner) ProvisionHostPath(ctx context.Context, opts pvController.P
 		)
 	}
 
-	if volumeConfig.IsExt4QuotaEnabled() {
-		softLimitGrace := volumeConfig.getDataField(KeyEXT4Quota, KeyQuotaSoftLimit)
-		hardLimitGrace := volumeConfig.getDataField(KeyEXT4Quota, KeyQuotaHardLimit)
-		pvcStorage := opts.PVC.Spec.Resources.Requests.Storage().Value()
-
-		podOpts := &HelperPodOptions{
-			name:               name,
-			path:               path,
-			nodeAffinityLabels: nodeAffinityLabels,
-			serviceAccountName: saName,
-			selectedNodeTaints: taints,
-			imagePullSecrets:   imagePullSecrets,
-			softLimitGrace:     softLimitGrace,
-			hardLimitGrace:     hardLimitGrace,
-			pvcStorage:         pvcStorage,
-			hostNetwork:        hostNetwork,
-		}
-		iErr := p.createQuotaPod(ctx, podOpts)
+	// Create volume locally if node deployment is enabled
+	if p.nodeDeployment {
+		iErr = p.createVolumeLocally(ctx, podOpts, enableQuota)
 		if iErr != nil {
-			klog.Infof("Applying quota failed: %v", iErr)
+			klog.Errorf("Create volume locally %v failed: %v", name, iErr)
 			alertlog.Logger.Errorw("",
 				"eventcode", "local.pv.provision.failure",
 				"msg", "Failed to provision Local PV",
 				"rname", opts.PVName,
-				"reason", "Quota enforcement failed",
+				"reason", "Local volume creation failed",
 				"storagetype", stgType,
 			)
 			return nil, pvController.ProvisioningFinished, iErr
 		}
-		alertlog.Logger.Infow("",
-			"eventcode", "local.pv.quota.success",
-			"msg", "Successfully applied quota",
-			"rname", opts.PVName,
-			"storagetype", stgType,
-		)
 	}
 
 	// VolumeMode will always be specified as Filesystem for host path volume,
@@ -184,11 +194,17 @@ func (p *Provisioner) ProvisionHostPath(ctx context.Context, opts pvController.P
 	labels[string(mconfig.CASTypeKey)] = "local-" + stgType
 	//labels[string(v1alpha1.StorageClassKey)] = *className
 
+	// Get the reclaim policy, defaulting to Delete if not specified
+	reclaimPolicy := v1.PersistentVolumeReclaimDelete
+	if opts.StorageClass != nil && opts.StorageClass.ReclaimPolicy != nil {
+		reclaimPolicy = *opts.StorageClass.ReclaimPolicy
+	}
+
 	//TODO Change the following to a builder pattern
 	pvObj, err := persistentvolume.NewBuilder().
 		WithName(name).
 		WithLabels(labels).
-		WithReclaimPolicy(*opts.StorageClass.ReclaimPolicy).
+		WithReclaimPolicy(reclaimPolicy).
 		WithAccessModes(pvc.Spec.AccessModes).
 		WithVolumeMode(fs).
 		WithCapacityQty(pvc.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]).
@@ -276,9 +292,9 @@ func (p *Provisioner) DeleteHostPath(ctx context.Context, pv *v1.PersistentVolum
 
 	//Initiate clean up only when reclaim policy is not retain.
 	klog.Infof("Deleting volume %v at %v:%v", pv.Name, GetNodeHostname(nodeObject), path)
-	cleanupCmdsForPath := []string{"rm", "-rf"}
+
 	podOpts := &HelperPodOptions{
-		cmdsForPath:        cleanupCmdsForPath,
+		cmdsForPath:        nil,
 		name:               pv.Name,
 		path:               path,
 		nodeAffinityLabels: nodeAffinityLabels,
@@ -288,8 +304,17 @@ func (p *Provisioner) DeleteHostPath(ctx context.Context, pv *v1.PersistentVolum
 		hostNetwork:        hostNetwork,
 	}
 
-	if err := p.createCleanupPod(ctx, podOpts); err != nil {
-		return errors.Wrapf(err, "clean up volume %v failed", pv.Name)
+	// In node deployment mode, use local operations directly
+	// Otherwise, fallback to helper pods
+	var cleanupErr error
+	if p.nodeDeployment {
+		cleanupErr = p.deleteVolumeLocally(ctx, podOpts)
+	} else {
+		cleanupErr = p.createCleanupPod(ctx, podOpts)
+	}
+
+	if cleanupErr != nil {
+		return errors.Wrapf(cleanupErr, "clean up volume %v failed", pv.Name)
 	}
 	return nil
 }

--- a/cmd/provisioner-localpv/app/start.go
+++ b/cmd/provisioner-localpv/app/start.go
@@ -23,6 +23,7 @@ var (
 	// localpv provisioner
 	LeaderElectionKey = "LEADER_ELECTION_ENABLED"
 	usage             = cmdName
+	nodeDeployment    bool
 )
 
 // StartProvisioner will start a new dynamic Host Path PV provisioner
@@ -38,6 +39,9 @@ func StartProvisioner() (*cobra.Command, error) {
 			util.CheckErr(Start(cmd), util.Fatal)
 		},
 	}
+
+	// Add node deployment flag
+	cmd.Flags().BoolVar(&nodeDeployment, "node-deployment", false, "Enables deploying the provisioner together with a CSI driver on nodes to manage node-local volumes")
 
 	return cmd, nil
 }
@@ -73,14 +77,35 @@ func Start(cmd *cobra.Command) error {
 		return err
 	}
 
+	// Set node deployment mode in provisioner
+	provisioner.nodeDeployment = nodeDeployment
+
+	// In node deployment mode, set the current node name for filtering
+	if nodeDeployment {
+		provisioner.nodeName = getNodeName()
+		if provisioner.nodeName == "" {
+			return errors.New("NODE_NAME environment variable is required in node-deployment mode")
+		}
+		klog.Infof("Node deployment mode enabled on node: %s", provisioner.nodeName)
+	}
+
 	//Create an instance of the Dynamic Provisioner Controller
 	// that has the reconciliation loops for PVC create and delete
 	// events and invokes the Provisioner Handler.
+	var leaderElection bool
+	if nodeDeployment {
+		// In node deployment mode, disable leader election as each node will have its own provisioner
+		leaderElection = false
+		klog.Info("Node deployment mode enabled, leader election disabled")
+	} else {
+		leaderElection = isLeaderElectionEnabled()
+	}
+
 	pc := pvController.NewProvisionController(
 		kubeClient,
 		provisionerName,
 		provisioner,
-		pvController.LeaderElection(isLeaderElectionEnabled()),
+		pvController.LeaderElection(leaderElection),
 	)
 
 	if menv.Truthy(menv.OpenEBSEnableAnalytics) {

--- a/cmd/provisioner-localpv/app/types.go
+++ b/cmd/provisioner-localpv/app/types.go
@@ -12,7 +12,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
 */
 
 package app
@@ -34,9 +33,11 @@ const (
 // Provisioner struct has the configuration and utilities required
 // across the different work-flows.
 type Provisioner struct {
-	kubeClient  *clientset.Clientset
-	namespace   string
-	helperImage string
+	kubeClient     *clientset.Clientset
+	namespace      string
+	helperImage    string
+	nodeDeployment bool
+	nodeName       string // Current node name (used in node-deployment mode)
 	// defaultConfig is the default configurations
 	// provided from ENV or Code
 	defaultConfig []mconfig.Config

--- a/deploy/helm/charts/templates/daemonset.yaml
+++ b/deploy/helm/charts/templates/daemonset.yaml
@@ -1,10 +1,9 @@
 {{- if .Values.localpv.enabled }}
-{{- if not .Values.localpv.nodeDeployment.enabled }}
+{{- if .Values.localpv.nodeDeployment.enabled }}
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
-  name: {{ template "localpv.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ template "localpv.fullname" . }}-node
   {{- with .Values.localpv.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
@@ -14,10 +13,6 @@ metadata:
       {{- toYaml .Values.extraLabels | nindent 4 }}
     {{- end }}
 spec:
-  replicas: {{ .Values.localpv.replicas }}
-  strategy:
-    type: "Recreate"
-    rollingUpdate: null
   selector:
     matchLabels:
       {{- include "localpv.selectorLabels" . | nindent 6 }}
@@ -52,6 +47,10 @@ spec:
       - name: {{ template "localpv.fullname" . }}
         image: "{{ with .Values.localpv.image.registry | default .Values.global.imageRegistry | trimSuffix "/" }}{{ . }}/{{ end }}{{ .Values.localpv.image.repository }}:{{ .Values.localpv.image.tag }}"
         imagePullPolicy: {{ .Values.localpv.image.pullPolicy }}
+        {{- if .Values.localpv.privileged }}
+        securityContext:
+          privileged: true
+        {{- end }}
         resources:
 {{ toYaml .Values.localpv.resources | indent 10 }}
         env:
@@ -99,14 +98,18 @@ spec:
           value: "{{ .Values.helperPod.hostNetwork }}"
         - name: OPENEBS_IO_INSTALLER_TYPE
           value: "localpv-charts-helm"
-        # LEADER_ELECTION_ENABLED is used to enable/disable leader election. By default
-        # leader election is enabled.
+        # Disable leader election in node deployment mode
         - name: LEADER_ELECTION_ENABLED
-          value: "{{ .Values.localpv.enableLeaderElection }}"
+          value: "false"
+        # Enable node deployment mode
+        - name: NODE_DEPLOYMENT
+          value: "true"
 {{- if .Values.imagePullSecrets }}
         - name: OPENEBS_IO_IMAGE_PULL_SECRETS
           value: "{{- range $index, $secret := .Values.imagePullSecrets}}{{if $index}},{{end}}{{ $secret.name }}{{- end}}"
 {{- end }}
+        args:
+        - "--node-deployment=true"
         # Process name used for matching is limited to the 15 characters
         # present in the pgrep output.
         # So fullname can't be used here with pgrep (>15 chars).A regular expression
@@ -121,6 +124,32 @@ spec:
             - test `pgrep -c "^provisioner-loc.*"` = 1
           initialDelaySeconds: {{ .Values.localpv.healthCheck.initialDelaySeconds }}
           periodSeconds: {{ .Values.localpv.healthCheck.periodSeconds }}
+        volumeMounts:
+        - name: basepath
+          mountPath: {{ .Values.localpv.basePath | quote }}
+          mountPropagation: HostToContainer
+        - name: dev
+          mountPath: /dev
+        - name: host-proc
+          mountPath: /host/proc
+          readOnly: true
+{{- if .Values.localpv.nodeDeployment.additionalVolumeMounts }}
+{{ toYaml .Values.localpv.nodeDeployment.additionalVolumeMounts | indent 8 }}
+{{- end }}
+      volumes:
+      - name: basepath
+        hostPath:
+          path: {{ .Values.localpv.basePath | quote }}
+          type: DirectoryOrCreate
+      - name: dev
+        hostPath:
+          path: /dev
+      - name: host-proc
+        hostPath:
+          path: /proc
+{{- if .Values.localpv.nodeDeployment.additionalVolumes }}
+{{ toYaml .Values.localpv.nodeDeployment.additionalVolumes | indent 6 }}
+{{- end }}
 {{- if .Values.localpv.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.localpv.nodeSelector | indent 8 }}

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -46,6 +46,13 @@ localpv:
   replicas: 1
   enableLeaderElection: true
   basePath: "/var/openebs/local"
+  # Node deployment configuration for distributed provisioning mode
+  nodeDeployment:
+    enabled: false
+    # Additional volume mounts for the provisioner container
+    additionalVolumeMounts: []
+    # Additional volumes for the provisioner pod
+    additionalVolumes: []
   resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
This PR introduces a node-deployment mode for the OpenEBS Dynamic LocalPV 
Provisioner, addressing performance bottlenecks identified in openebs/openebs#4050.

Key Changes:
- New `--node-deployment=true` flag to run provisioner as DaemonSet on each node
- Direct local volume operations (mkdir, quota, rm) without helper pods
- Automatic node filtering using IgnoredError for proper multi-instance coordination
- Leader election disabled in node-deployment mode

Benefits:
- Eliminates helper pod creation/termination overhead
- Reduces PVC binding latency significantly
- Decreases API server load
- Simpler architecture than external service approach



Solve xfs/ext projId Issues
Solve race conditions Issues

https://github.com/openebs/dynamic-localpv-provisioner/issues/289
https://github.com/openebs/dynamic-localpv-provisioner/pull/290