### PR TITLE
fix(helm): add explicit namespace to Deployment and ServiceAccount templates

### DIFF
--- a/deploy/helm/charts/templates/deployment.yaml
+++ b/deploy/helm/charts/templates/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "localpv.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.localpv.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}

--- a/deploy/helm/charts/templates/rbac.yaml
+++ b/deploy/helm/charts/templates/rbac.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "localpv.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "localpv.labels" . | nindent 4 }}
     {{- if .Values.extraLabels -}}


### PR DESCRIPTION
## Pull Request template

**Why is this PR required? What issue does it fix?**:

The Deployment and ServiceAccount templates do not include an explicit namespace field. This works fine with `helm install` (which uses something equivalent to `kubectl apply --namespace <ns>` and puts the objects in the correct namespace) but breaks `helm template` workflows where the rendered manifests are used directly.

This also fixes an inconsistency: ClusterRoleBinding already references {{ .Release.Namespace }} for the ServiceAccount subject, but the ServiceAccount itself omits it. With a `helm template` workflow this can lead to the ClusterRoleBinding referencing a ServiceAccount in a different namespace than the ServiceAccount itself.

**What this PR does?**:

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

This change should have no effect on most workflows, but significantly improves these:
- Kustomize's built-in helmCharts feature
- GitOps pipelines that render and version manifests before deployment
- Any workflow based on `helm template` output

**Any additional information for your reviewer?** : 

I'm in the same boat as #284 and took up the work.


**Checklist:**
- [x] Fixes #284 PR
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
~- [ ] Commit has unit tests~
~- [ ] Commit has integration tests~
~- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:~
~- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:~
