### PR TITLE
ci: bump trivy-action workflow

### DIFF
--- a/.github/workflows/trivy-ci.yml
+++ b/.github/workflows/trivy-ci.yml
@@ -37,7 +37,7 @@ jobs:
           '
 
       - name: Trivy Helm misconfiguration scan
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@0.34.2
         with:
             scan-type: config
             scan-ref: deploy/helm/charts/rendered.yaml

--- a/deploy/helm/charts/templates/_helpers.tpl
+++ b/deploy/helm/charts/templates/_helpers.tpl
@@ -89,3 +89,75 @@ Usage:
     {{- toYaml .Values.localpv.tolerations | nindent 8 }}
 {{- end }}
 {{- end }}
+
+{{/*
+Creates the image URL ie registry/repository:tag
+*/}}
+{{- define "localpv.common.image" -}}
+{{- $registryName := default .imageRoot.registry ((.global).imageRegistry) | trimSuffix "/" -}}
+{{- $repositoryName := .imageRoot.repository -}}
+{{- $separator := ":" -}}
+{{- $termination := .imageRoot.tag | toString -}}
+{{- if $registryName }}
+    {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $termination -}}
+{{- else -}}
+    {{- printf "%s%s%s"  $repositoryName $separator $termination -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Concatenates imagepullsecrets, outputs in ENV format and handles different formats (example - secret or - name: secret)
+*/}}
+{{- define "localpv.helper.pullSecrets" -}}
+
+{{- $pullSecrets := list }}
+
+{{- with .Values.global.imagePullSecrets }}
+  {{- $pullSecrets = concat $pullSecrets . }}
+{{- end }}
+
+{{- with .Values.imagePullSecrets }}
+  {{- $pullSecrets = concat $pullSecrets . }}
+{{- end }}
+
+{{- $names := list }}
+
+{{- range $pullSecrets | uniq }}
+  {{- if kindIs "map" . }}
+    {{- $names = append $names .name }}
+  {{- else }}
+    {{- $names = append $names . }}
+  {{- end }}
+{{- end }}
+
+{{- if $names }}
+- name: OPENEBS_IO_IMAGE_PULL_SECRETS
+  value: "{{ join "," ($names | uniq) }}"
+{{- end }}
+{{- end }}
+
+{{/*
+Concatenates imagepullsecrets and handles different formats (example - secret or - name: secret)
+*/}}
+{{- define "localpv.common.pullSecrets" -}}
+{{- $pullSecrets := list }}
+
+{{- with .Values.global.imagePullSecrets }}
+{{- $pullSecrets = concat $pullSecrets . }}
+{{- end }}
+
+{{- with .Values.imagePullSecrets }}
+{{- $pullSecrets = concat $pullSecrets . }}
+{{- end }}
+
+{{- if $pullSecrets }}
+imagePullSecrets:
+{{- range $pullSecrets | uniq }}
+  {{- if kindIs "map" . }}
+- name: {{ .name }}
+  {{- else }}
+- name: {{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/charts/templates/daemonset.yaml
+++ b/deploy/helm/charts/templates/daemonset.yaml
@@ -36,17 +36,14 @@ spec:
     {{- if .Values.localpv.priorityClassName }}
       priorityClassName: {{ tpl .Values.localpv.priorityClassName . }}
     {{- end }}
-    {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+{{- include "localpv.common.pullSecrets" . | indent 6 }}
       serviceAccountName: {{ template "localpv.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
       - name: {{ template "localpv.fullname" . }}
-        image: "{{ with .Values.localpv.image.registry | default .Values.global.imageRegistry | trimSuffix "/" }}{{ . }}/{{ end }}{{ .Values.localpv.image.repository }}:{{ .Values.localpv.image.tag }}"
-        imagePullPolicy: {{ .Values.localpv.image.pullPolicy }}
+        image: {{ include "localpv.common.image" (dict "imageRoot" .Values.localpv.image "global" .Values.global)}}
+        imagePullPolicy: {{ default .Values.localpv.image.pullPolicy .Values.global.imagePullPolicy }}
         {{- if .Values.localpv.privileged }}
         securityContext:
           privileged: true
@@ -80,8 +77,13 @@ spec:
               fieldPath: spec.serviceAccountName
         # OPENEBS_IO_BASE_PATH is the environment variable that provides the
         # default base path on the node where host-path PVs will be provisioned.
+        {{-  if kindIs "bool" .Values.global.analytics.enabled }}
+        - name: OPENEBS_IO_ENABLE_ANALYTICS
+          value: "{{ .Values.global.analytics.enabled }}"
+        {{- else }}
         - name: OPENEBS_IO_ENABLE_ANALYTICS
           value: "{{ .Values.analytics.enabled }}"
+        {{- end }}
         {{- if .Values.analytics.gaId }}
         - name: GA_ID
           value: {{ .Values.analytics.gaId | quote }}
@@ -93,7 +95,7 @@ spec:
         - name: OPENEBS_IO_BASE_PATH
           value: "{{ .Values.localpv.basePath }}"
         - name: OPENEBS_IO_HELPER_IMAGE
-          value: "{{ with .Values.helperPod.image.registry | default .Values.global.imageRegistry | trimSuffix "/" }}{{ . }}/{{ end }}{{ .Values.helperPod.image.repository }}:{{ .Values.helperPod.image.tag }}"
+          value: {{ include "localpv.common.image" (dict "imageRoot" .Values.helperPod.image "global" .Values.global)}}
         - name: OPENEBS_IO_HELPER_POD_HOST_NETWORK
           value: "{{ .Values.helperPod.hostNetwork }}"
         - name: OPENEBS_IO_INSTALLER_TYPE
@@ -104,10 +106,7 @@ spec:
         # Enable node deployment mode
         - name: NODE_DEPLOYMENT
           value: "true"
-{{- if .Values.imagePullSecrets }}
-        - name: OPENEBS_IO_IMAGE_PULL_SECRETS
-          value: "{{- range $index, $secret := .Values.imagePullSecrets}}{{if $index}},{{end}}{{ $secret.name }}{{- end}}"
-{{- end }}
+{{- include "localpv.helper.pullSecrets" . | indent 8 }}
         args:
         - "--node-deployment=true"
         # Process name used for matching is limited to the 15 characters

--- a/deploy/helm/charts/templates/deployment.yaml
+++ b/deploy/helm/charts/templates/deployment.yaml
@@ -41,17 +41,14 @@ spec:
     {{- if .Values.localpv.priorityClassName }}
       priorityClassName: {{ tpl .Values.localpv.priorityClassName . }}
     {{- end }}
-    {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+{{- include "localpv.common.pullSecrets" . | indent 6 }}
       serviceAccountName: {{ template "localpv.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
       - name: {{ template "localpv.fullname" . }}
-        image: "{{ with .Values.localpv.image.registry | default .Values.global.imageRegistry | trimSuffix "/" }}{{ . }}/{{ end }}{{ .Values.localpv.image.repository }}:{{ .Values.localpv.image.tag }}"
-        imagePullPolicy: {{ .Values.localpv.image.pullPolicy }}
+        image: {{ include "localpv.common.image" (dict "imageRoot" .Values.localpv.image "global" .Values.global)}}
+        imagePullPolicy: {{ default .Values.localpv.image.pullPolicy .Values.global.imagePullPolicy}}
         resources:
 {{ toYaml .Values.localpv.resources | indent 10 }}
         env:
@@ -82,7 +79,7 @@ spec:
         # OPENEBS_IO_BASE_PATH is the environment variable that provides the
         # default base path on the node where host-path PVs will be provisioned.
         - name: OPENEBS_IO_ENABLE_ANALYTICS
-          value: "{{ .Values.analytics.enabled }}"
+          value: "{{default .Values.analytics.enabled .Values.global.analytics.enabled }}"
         {{- if .Values.analytics.gaId }}
         - name: GA_ID
           value: {{ .Values.analytics.gaId | quote }}
@@ -94,7 +91,7 @@ spec:
         - name: OPENEBS_IO_BASE_PATH
           value: "{{ .Values.localpv.basePath }}"
         - name: OPENEBS_IO_HELPER_IMAGE
-          value: "{{ with .Values.helperPod.image.registry | default .Values.global.imageRegistry | trimSuffix "/" }}{{ . }}/{{ end }}{{ .Values.helperPod.image.repository }}:{{ .Values.helperPod.image.tag }}"
+          value: {{ include "localpv.common.image" (dict "imageRoot" .Values.helperPod.image "global" .Values.global)}}
         - name: OPENEBS_IO_HELPER_POD_HOST_NETWORK
           value: "{{ .Values.helperPod.hostNetwork }}"
         - name: OPENEBS_IO_INSTALLER_TYPE
@@ -103,10 +100,7 @@ spec:
         # leader election is enabled.
         - name: LEADER_ELECTION_ENABLED
           value: "{{ .Values.localpv.enableLeaderElection }}"
-{{- if .Values.imagePullSecrets }}
-        - name: OPENEBS_IO_IMAGE_PULL_SECRETS
-          value: "{{- range $index, $secret := .Values.imagePullSecrets}}{{if $index}},{{end}}{{ $secret.name }}{{- end}}"
-{{- end }}
+{{- include "localpv.helper.pullSecrets" . | indent 8 }}
         # Process name used for matching is limited to the 15 characters
         # present in the pgrep output.
         # So fullname can't be used here with pgrep (>15 chars).A regular expression

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -3,9 +3,15 @@
 # Declare variables to be passed into your templates.
 
 global:
-  # Used as default image registry, values supplied by localpv.image.registry
-  # and helperPod.image.registry override this value.
-  imageRegistry: "docker.io"
+  # Global override for container image registry.
+  imageRegistry: ""
+  # - secret
+  imagePullSecrets: []
+  # Global overide for image pull policy
+  imagePullPolicy: ""
+  analytics:
+    # Global overide for analytics
+    enabled:
 
 rbac:
   # rbac.create: `true` if rbac resources should be created
@@ -27,7 +33,7 @@ localpv:
   name: localpv-provisioner
   enabled: true
   image:
-    registry: ""
+    registry: "docker.io"
     repository: openebs/provisioner-localpv
     tag: 4.5.0-develop
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Why is this PR required? What issue does it fix?

Currently, the Helm charts do not provide global variables for configuring common parameters such as the image registry, image pull secrets, image pull policy, and analytics settings.

When deploying the OpenEBS Helm charts, users often need to override these values across multiple subcharts and components. This makes it difficult to locate and configure all the required fields consistently. Providing global variables simplifies configuration and improves the user experience.

## What does this PR do?

This PR introduces the following global configuration variables:
```yaml
global:
  # Global override for container image registry.
  imageRegistry: ""
  # - secret
  imagePullSecrets: []
  # Global overide for image pull policy
  imagePullPolicy: ""
  analytics:
    # Global overide for analytics
    enabled:
```

These variables allow users to configure common settings in a single place, which will then be applied across the chart components.

## Does this PR require any upgrade changes?

No.

## Verification

The changes were verified using the following scenarios:

Rendered the templates using helm template to confirm correct value substitution.

Deployed the chart on a Kubernetes cluster with 3 worker nodes (kubeadm-based setup).

Verified that the global values are rendered and applied correctly across the components.