### PR TITLE
refactor(quota): move quota scripts to its own file

### DIFF
--- a/cmd/provisioner-localpv/app/helper_hostpath.go
+++ b/cmd/provisioner-localpv/app/helper_hostpath.go
@@ -212,15 +212,13 @@ func (p *Provisioner) createCleanupPod(ctx context.Context, pOpts *HelperPodOpti
 
 	config.taints = pOpts.selectedNodeTaints
 
-	// Generate cleanup script using shared utility
-	// Helper pod mounts parentDir at /data, so use /data as the parent path
-	cleanupScript := GenerateQuotaCleanupScript(QuotaScriptConfig{
+	// Generate cleanup argv using shared utility.
+	// Helper pod mounts parentDir at /data, so use /data as the parent path.
+	config.pOpts.cmdsForPath = QuotaScriptConfig{
 		ParentDir:      "/data",
 		VolumeDir:      config.volumeDir,
 		HostPathPrefix: "", // No prefix needed, /data is the mount point
-	})
-
-	config.pOpts.cmdsForPath = []string{"sh", "-c", cleanupScript}
+	}.CleanupArgs()
 
 	_, err := p.launchPod(ctx, config)
 	if err != nil && !k8serror.IsAlreadyExists(err) {
@@ -273,17 +271,15 @@ func (p *Provisioner) createQuotaPod(ctx context.Context, pOpts *HelperPodOption
 		return err
 	}
 
-	// Generate quota script using shared utility
-	// Helper pod mounts parentDir at /data, so use /data as the parent path
-	quotaScript := GenerateQuotaApplyScript(QuotaScriptConfig{
+	// Generate quota apply argv using shared utility.
+	// Helper pod mounts parentDir at /data, so use /data as the parent path.
+	config.pOpts.cmdsForPath = QuotaScriptConfig{
 		ParentDir:      "/data",
 		VolumeDir:      config.volumeDir,
 		SoftLimitGrace: config.pOpts.softLimitGrace,
 		HardLimitGrace: config.pOpts.hardLimitGrace,
 		HostPathPrefix: "", // No prefix needed, /data is the mount point
-	})
-
-	config.pOpts.cmdsForPath = []string{"sh", "-c", quotaScript}
+	}.ApplyArgs()
 
 	_, err := p.launchPod(ctx, config)
 	if err != nil && !k8serror.IsAlreadyExists(err) {

--- a/cmd/provisioner-localpv/app/local_volume_manager.go
+++ b/cmd/provisioner-localpv/app/local_volume_manager.go
@@ -101,15 +101,15 @@ func (vm *LocalVolumeManager) DeleteVolume(ctx context.Context, req *VolumeReque
 		return fmt.Errorf("failed to extract paths: %v", err)
 	}
 
-	// Generate cleanup script using shared utility
+	// Generate cleanup argv using shared utility
 	// Node deployment mode accesses host filesystem via HostPathPrefix
-	cleanupScript := GenerateQuotaCleanupScript(QuotaScriptConfig{
+	cleanupArgs := QuotaScriptConfig{
 		ParentDir:      parentDir,
 		VolumeDir:      volumeDir,
 		HostPathPrefix: HostPathPrefix,
-	})
+	}.CleanupArgs()
 
-	if err := vm.executeCommand(ctx, "sh", "-c", cleanupScript); err != nil {
+	if err := vm.executeCommand(ctx, cleanupArgs[0], cleanupArgs[1:]...); err != nil {
 		return fmt.Errorf("failed to delete directory: %v", err)
 	}
 
@@ -254,16 +254,15 @@ func (vm *LocalVolumeManager) validateLimits(softLimitGrace, hardLimitGrace stri
 
 // applyQuotaByFilesystem applies quota based on the filesystem type
 func (vm *LocalVolumeManager) applyQuotaByFilesystem(ctx context.Context, parentDir, volumeDir, softLimitGrace, hardLimitGrace string) error {
-	// Generate quota script using shared utility
+	// Generate quota apply argv using shared utility
 	// Node deployment mode accesses host filesystem via HostPathPrefix
-	script := GenerateQuotaApplyScript(QuotaScriptConfig{
+	args := QuotaScriptConfig{
 		ParentDir:      parentDir,
 		VolumeDir:      volumeDir,
 		SoftLimitGrace: softLimitGrace,
 		HardLimitGrace: hardLimitGrace,
 		HostPathPrefix: HostPathPrefix,
-	})
+	}.ApplyArgs()
 
-	// Execute the quota script
-	return vm.executeCommand(ctx, "sh", "-c", script)
+	return vm.executeCommand(ctx, args[0], args[1:]...)
 }

--- a/cmd/provisioner-localpv/app/quota.sh
+++ b/cmd/provisioner-localpv/app/quota.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+# OpenEBS dynamic-localpv-provisioner quota helper.
+#
+# Applies or removes a filesystem project quota on a directory whose parent
+# resides on an XFS or EXT2/3/4 filesystem with project quotas enabled.
+#
+# Usage:
+#   quota.sh apply   --parent <path> --volume <path> --soft-kb <n> --hard-kb <n>
+#   quota.sh cleanup --parent <path> --volume <path>
+
+set -e
+
+die() { echo "$@" >&2; exit 1; }
+
+usage() {
+    cat >&2 <<'EOF'
+Usage:
+  quota.sh apply   --parent <path> --volume <path> --soft-kb <n> --hard-kb <n>
+  quota.sh cleanup --parent <path> --volume <path>
+EOF
+    exit 2
+}
+
+mode=
+parent=
+volume=
+soft_kb=
+hard_kb=
+
+[ $# -ge 1 ] || usage
+mode=$1; shift
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --parent)  [ $# -ge 2 ] || die "--parent needs a value";  parent=$2;  shift 2 ;;
+        --volume)  [ $# -ge 2 ] || die "--volume needs a value";  volume=$2;  shift 2 ;;
+        --soft-kb) [ $# -ge 2 ] || die "--soft-kb needs a value"; soft_kb=$2; shift 2 ;;
+        --hard-kb) [ $# -ge 2 ] || die "--hard-kb needs a value"; hard_kb=$2; shift 2 ;;
+        *) die "unknown argument: $1" ;;
+    esac
+done
+
+[ -n "$parent" ] || die "missing --parent"
+[ -n "$volume" ] || die "missing --volume"
+
+fs=$(stat -f -c %T "$volume" 2>/dev/null || echo "unknown")
+
+case "$mode" in
+    apply)
+        [ -n "$soft_kb" ] || die "missing --soft-kb"
+        [ -n "$hard_kb" ] || die "missing --hard-kb"
+        case "$fs" in
+            xfs)
+                pid=$(xfs_quota -x -c 'report -h' "$parent" 2>/dev/null | tail -2 | awk 'NR==1{print substr ($1,2)}+0' || echo "0")
+                pid=$((pid + 1))
+                xfs_quota -x -c "project -s -p $volume $pid" "$parent"
+                xfs_quota -x -c "limit -p bsoft=${soft_kb}k bhard=${hard_kb}k $pid" "$parent"
+                ;;
+            ext2/ext3)
+                pid=$(repquota -P "$parent" 2>/dev/null | tail -3 | awk 'NR==1{print substr ($1,2)}+0' || echo "0")
+                pid=$((pid + 1))
+                chattr +P -p "$pid" "$volume"
+                # setquota -P expects block limits as plain numbers (in KB blocks).
+                setquota -P "$pid" "$soft_kb" "$hard_kb" 0 0 "$parent"
+                ;;
+            *)
+                echo "Unsupported filesystem type: $fs" >&2
+                rm -rf "$volume"
+                exit 1
+                ;;
+        esac
+        ;;
+    cleanup)
+        case "$fs" in
+            xfs)
+                id=$(xfs_io -c stat "$volume" 2>/dev/null | awk '/projid/{print $3}' | head -1)
+                echo "projid=$id"
+                if [ -n "$id" ] && [ "$id" != "0" ]; then
+                    xfs_io -c "chproj -R 0" "$volume" 2>/dev/null || true
+                    xfs_quota -x -c "limit -p bsoft=0 bhard=0 $id" "$parent" 2>/dev/null || true
+                fi
+                ;;
+            ext2/ext3)
+                id=$(lsattr -pd "$volume"/ 2>/dev/null | awk '{print $1}')
+                if [ -n "$id" ] && [ "$id" != "0" ]; then
+                    setquota -P "$id" 0 0 0 0 "$parent" 2>/dev/null || true
+                fi
+                ;;
+        esac
+        rm -rf "$volume"
+        ;;
+    *)
+        die "unknown mode: $mode (expected 'apply' or 'cleanup')"
+        ;;
+esac

--- a/cmd/provisioner-localpv/app/quota_scripts.go
+++ b/cmd/provisioner-localpv/app/quota_scripts.go
@@ -1,122 +1,72 @@
 package app
 
 import (
-	"fmt"
+	_ "embed"
 	"path/filepath"
 	"strings"
 )
 
-// QuotaScriptConfig holds configuration for generating quota scripts
+// quotaScript is the body of quota.sh, embedded at compile time. The
+// script handles both `apply` and `cleanup` modes and parses its own
+// flags; see quota.sh for the full interface. We pass the script body to
+// `sh -c` and let callers invoke modes uniformly through argv built by
+// [QuotaScriptConfig.ApplyArgs] and [QuotaScriptConfig.CleanupArgs].
+//
+//go:embed quota.sh
+var quotaScript string
+
+// QuotaScriptConfig holds configuration for invoking the quota helper script.
 type QuotaScriptConfig struct {
-	// ParentDir is the base directory path where volumes are created
-	// For HelperPod: use "/data" (the mount point inside the container)
-	// For DaemonSet: use the actual host path (e.g., "/var/openebs/local")
+	// ParentDir is the base directory whose filesystem owns the quota tables.
+	// For HelperPod: use "/data" (the mount point inside the container).
+	// For NodeDeployment: use the actual host path (e.g., "/var/openebs/local").
 	ParentDir string
-	// VolumeDir is the volume subdirectory name (e.g., "pvc-xxx")
+	// VolumeDir is the volume subdirectory name (e.g., "pvc-xxx").
 	VolumeDir string
-	// SoftLimitGrace is the soft quota limit with 'k' suffix (e.g., "1024k")
+	// SoftLimitGrace is the soft quota limit with 'k' suffix (e.g., "1024k").
+	// Stripped to plain KB integer before being passed to the script.
 	SoftLimitGrace string
-	// HardLimitGrace is the hard quota limit with 'k' suffix (e.g., "1024k")
+	// HardLimitGrace is the hard quota limit with 'k' suffix (e.g., "1024k").
 	HardLimitGrace string
-	// HostPathPrefix is prepended to paths to access them from within the container
-	// For HelperPod: use "" (parentDir is already mounted at /data)
-	// For DaemonSet: use "/host" (host root is mounted at /host)
+	// HostPathPrefix is prepended to paths to access them from within the
+	// container. For HelperPod: "" (ParentDir is already mounted at /data).
+	// For NodeDeployment: "/host" (host root is mounted at /host).
 	HostPathPrefix string
 }
 
-// GenerateQuotaApplyScript generates a shell script to apply filesystem quota
-// This script:
-// 1. Detects filesystem type (XFS or EXT4)
-// 2. Applies project quota with the specified limits
-func GenerateQuotaApplyScript(cfg QuotaScriptConfig) string {
-	// Extract numeric values for EXT4 setquota (it expects plain numbers in KB blocks, not with suffix)
-	extSoftLimit := strings.TrimSuffix(cfg.SoftLimitGrace, "k")
-	extHardLimit := strings.TrimSuffix(cfg.HardLimitGrace, "k")
-
-	// Build paths with optional prefix
-	parentPath := cfg.ParentDir
-	volumePath := filepath.Join(cfg.ParentDir, cfg.VolumeDir)
+// resolvePaths returns the parent and volume paths with HostPathPrefix
+// applied (used by NodeDeployment mode, which mounts the host at /host).
+func (cfg QuotaScriptConfig) resolvePaths() (parentPath, volumePath string) {
+	parentPath = cfg.ParentDir
+	volumePath = filepath.Join(cfg.ParentDir, cfg.VolumeDir)
 	if cfg.HostPathPrefix != "" {
-		parentPath = filepath.Join(cfg.HostPathPrefix, cfg.ParentDir)
-		volumePath = filepath.Join(cfg.HostPathPrefix, cfg.ParentDir, cfg.VolumeDir)
+		parentPath = filepath.Join(cfg.HostPathPrefix, parentPath)
+		volumePath = filepath.Join(cfg.HostPathPrefix, volumePath)
 	}
-
-	return fmt.Sprintf(`set -e
-
-# Path to parent directory (mount point for quota commands)
-PARENT_PATH="%s"
-# Path to volume directory
-VOLUME_PATH="%s"
-
-# Get filesystem type
-FS=$(stat -f -c %%T "$VOLUME_PATH")
-
-if [[ "$FS" == "xfs" ]]; then
-    # Get the next available project ID
-    PID=$(xfs_quota -x -c 'report -h' "$PARENT_PATH" 2>/dev/null | tail -2 | awk 'NR==1{print substr ($1,2)}+0' || echo "0")
-    PID=$((PID + 1))
-    # Set up project for the volume directory
-    xfs_quota -x -c "project -s -p $VOLUME_PATH $PID" "$PARENT_PATH"
-    # Apply quota limits
-    xfs_quota -x -c "limit -p bsoft=%s bhard=%s $PID" "$PARENT_PATH"
-elif [[ "$FS" == "ext2/ext3" ]]; then
-    PID=$(repquota -P "$PARENT_PATH" 2>/dev/null | tail -3 | awk 'NR==1{print substr ($1,2)}+0' || echo "0")
-    PID=$((PID + 1))
-    chattr +P -p $PID "$VOLUME_PATH"
-    # setquota -P expects block limits as plain numbers (in KB blocks)
-    setquota -P $PID %s %s 0 0 "$PARENT_PATH"
-else
-    echo "Unsupported filesystem type: $FS"
-    rm -rf "$VOLUME_PATH"
-    exit 1
-fi`,
-		parentPath, volumePath,
-		cfg.SoftLimitGrace, cfg.HardLimitGrace, // xfs limits (with 'k' suffix)
-		extSoftLimit, extHardLimit, // ext quota limits (plain numbers in KB)
-	)
+	return parentPath, volumePath
 }
 
-// GenerateQuotaCleanupScript generates a shell script to remove filesystem quota and delete volume
-// This script:
-// 1. Detects filesystem type (XFS or EXT4)
-// 2. Removes project quota association
-// 3. Deletes the volume directory
-func GenerateQuotaCleanupScript(cfg QuotaScriptConfig) string {
-	// Build paths with optional prefix
-	parentPath := cfg.ParentDir
-	volumePath := filepath.Join(cfg.ParentDir, cfg.VolumeDir)
-	if cfg.HostPathPrefix != "" {
-		parentPath = filepath.Join(cfg.HostPathPrefix, cfg.ParentDir)
-		volumePath = filepath.Join(cfg.HostPathPrefix, cfg.ParentDir, cfg.VolumeDir)
+// ApplyArgs returns the argv to pass to exec for applying a quota. The
+// returned slice begins with "sh" and includes the embedded script body,
+// so the caller invokes it as e.g. `cmd.Args = cfg.ApplyArgs()`.
+func (cfg QuotaScriptConfig) ApplyArgs() []string {
+	parentPath, volumePath := cfg.resolvePaths()
+	return []string{
+		"sh", "-c", quotaScript, "quota.sh", "apply",
+		"--parent", parentPath,
+		"--volume", volumePath,
+		"--soft-kb", strings.TrimSuffix(cfg.SoftLimitGrace, "k"),
+		"--hard-kb", strings.TrimSuffix(cfg.HardLimitGrace, "k"),
 	}
+}
 
-	return fmt.Sprintf(`set -e
-
-# Path to parent directory (mount point for quota commands)
-PARENT_PATH="%s"
-# Path to volume directory
-VOLUME_PATH="%s"
-
-# Get filesystem type
-FS=$(stat -f -c %%T "$VOLUME_PATH" 2>/dev/null || echo "unknown")
-
-if [[ "$FS" == "xfs" ]]; then
-    ID=$(xfs_io -c stat "$VOLUME_PATH" 2>/dev/null | awk '/projid/{print $3}' | head -1)
-    echo "projid=$ID"
-    if [ -n "$ID" ] && [ "$ID" != "0" ]; then
-        # Remove projid binding
-        xfs_io -c "chproj -R 0" "$VOLUME_PATH" 2>/dev/null || true
-        # Remove quota limit
-        xfs_quota -x -c "limit -p bsoft=0 bhard=0 $ID" "$PARENT_PATH" 2>/dev/null || true
-    fi
-elif [[ "$FS" == "ext2/ext3" ]]; then
-    ID=$(lsattr -pd "$VOLUME_PATH"/ 2>/dev/null | awk '{print $1}')
-    if [ -n "$ID" ] && [ "$ID" != "0" ]; then
-        setquota -P $ID 0 0 0 0 "$PARENT_PATH" 2>/dev/null || true
-    fi
-fi
-
-rm -rf "$VOLUME_PATH"`,
-		parentPath, volumePath,
-	)
+// CleanupArgs returns the argv to pass to exec for cleaning up a quota and
+// removing the volume directory.
+func (cfg QuotaScriptConfig) CleanupArgs() []string {
+	parentPath, volumePath := cfg.resolvePaths()
+	return []string{
+		"sh", "-c", quotaScript, "quota.sh", "cleanup",
+		"--parent", parentPath,
+		"--volume", volumePath,
+	}
 }

--- a/cmd/provisioner-localpv/app/quota_scripts_test.go
+++ b/cmd/provisioner-localpv/app/quota_scripts_test.go
@@ -1,0 +1,224 @@
+package app
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The tests below execute the embedded quota.sh under the exact argv the
+// production code constructs (via ApplyArgs / CleanupArgs). To avoid
+// requiring a quota-enabled filesystem (or root), every external command
+// the script invokes (stat, xfs_quota, xfs_io, repquota, setquota, chattr,
+// lsattr) is replaced with a stub that records its invocation to a log
+// file and emits configurable synthetic stdout. The tests assert on the
+// log to verify the script invoked the right tools with the right
+// arguments.
+
+// dispatcherScript is the body of a single shell script that every stub
+// symlinks to. It records its invocation as "<name>: <args>" in ${STUB_LOG}
+// and emits synthetic stdout for the commands whose output the quota
+// script parses. Controlled via env vars:
+//
+//	STUB_FS      - filesystem type echoed by `stat -f -c %T`
+//	STUB_PROJID  - project ID surfaced by `xfs_io -c stat` and `lsattr -pd`
+const dispatcherScript = `#!/bin/sh
+name=$(basename "$0")
+printf '%s: %s\n' "$name" "$*" >> "${STUB_LOG}"
+case "$name" in
+    stat)   echo "${STUB_FS:-xfs}" ;;
+    xfs_io) echo "fsxattr.projid = ${STUB_PROJID:-1}" ;;
+    lsattr) echo "${STUB_PROJID:-1} ----P--------e----- /placeholder/" ;;
+esac
+exit 0
+`
+
+// stubbedCommands is the set of external commands quota.sh may invoke.
+// Each gets a symlink to the dispatcher so its argv is captured.
+var stubbedCommands = []string{
+	"stat", "xfs_quota", "xfs_io", "repquota", "setquota",
+	"chattr", "lsattr",
+}
+
+// setupQuotaStubs creates a directory containing stub executables and
+// returns its path. The log file lives at <dir>/calls.log.
+func setupQuotaStubs(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	dispatcher := filepath.Join(dir, "_dispatch")
+	if err := os.WriteFile(dispatcher, []byte(dispatcherScript), 0o755); err != nil {
+		t.Fatalf("write dispatcher: %v", err)
+	}
+	for _, name := range stubbedCommands {
+		if err := os.Symlink(dispatcher, filepath.Join(dir, name)); err != nil {
+			t.Fatalf("symlink %s: %v", name, err)
+		}
+	}
+	return dir
+}
+
+// runQuotaArgs runs the given argv with stubDir at the front of PATH, then
+// returns the contents of calls.log for substring assertions.
+func runQuotaArgs(t *testing.T, stubDir string, argv []string, extraEnv map[string]string) string {
+	t.Helper()
+	logPath := filepath.Join(stubDir, "calls.log")
+	cmd := exec.Command(argv[0], argv[1:]...)
+	cmd.Env = append(os.Environ(),
+		"PATH="+stubDir+":"+os.Getenv("PATH"),
+		"STUB_LOG="+logPath,
+	)
+	for k, v := range extraEnv {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("script failed: %v\nscript stdout/stderr:\n%s", err, out)
+	}
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read calls.log: %v", err)
+	}
+	return strings.TrimSpace(string(logBytes))
+}
+
+// requireSh skips the test if /bin/sh isn't available (e.g., on Windows CI).
+func requireSh(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+}
+
+func TestQuotaScriptApply(t *testing.T) {
+	requireSh(t)
+
+	cases := map[string]struct {
+		fsType    string
+		wantCalls []string
+	}{
+		"xfs": {
+			fsType: "xfs",
+			wantCalls: []string{
+				"xfs_quota: -x -c report -h",
+				"xfs_quota: -x -c project -s -p",
+				"xfs_quota: -x -c limit -p bsoft=1024k bhard=1024k 1",
+			},
+		},
+		"ext4": {
+			fsType: "ext2/ext3",
+			wantCalls: []string{
+				"repquota: -P",
+				"chattr: +P -p 1",
+				"setquota: -P 1 1024 1024 0 0",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			stubDir := setupQuotaStubs(t)
+			cfg := QuotaScriptConfig{
+				ParentDir:      t.TempDir(),
+				VolumeDir:      "pvc-abc",
+				SoftLimitGrace: "1024k",
+				HardLimitGrace: "1024k",
+			}
+			calls := runQuotaArgs(t, stubDir, cfg.ApplyArgs(), map[string]string{
+				"STUB_FS": tc.fsType,
+			})
+			for _, want := range tc.wantCalls {
+				if !strings.Contains(calls, want) {
+					t.Errorf("expected call %q in calls.log:\n%s", want, calls)
+				}
+			}
+		})
+	}
+}
+
+func TestQuotaScriptCleanup(t *testing.T) {
+	requireSh(t)
+
+	cases := map[string]struct {
+		fsType    string
+		projid    string
+		wantCalls []string
+	}{
+		"xfs": {
+			fsType: "xfs",
+			projid: "1",
+			wantCalls: []string{
+				"xfs_io: -c stat",
+				"xfs_io: -c chproj -R 0",
+				"xfs_quota: -x -c limit -p bsoft=0 bhard=0 1",
+			},
+		},
+		"ext4": {
+			fsType: "ext2/ext3",
+			projid: "1",
+			wantCalls: []string{
+				"lsattr: -pd",
+				"setquota: -P 1 0 0 0 0",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			stubDir := setupQuotaStubs(t)
+			cfg := QuotaScriptConfig{
+				ParentDir: t.TempDir(),
+				VolumeDir: "pvc-abc",
+			}
+			calls := runQuotaArgs(t, stubDir, cfg.CleanupArgs(), map[string]string{
+				"STUB_FS":     tc.fsType,
+				"STUB_PROJID": tc.projid,
+			})
+			for _, want := range tc.wantCalls {
+				if !strings.Contains(calls, want) {
+					t.Errorf("expected call %q in calls.log:\n%s", want, calls)
+				}
+			}
+		})
+	}
+}
+
+// TestResolvePaths covers the HostPathPrefix handling, which the
+// execution-based tests above don't touch because they need writable
+// paths under t.TempDir().
+func TestResolvePaths(t *testing.T) {
+	cases := map[string]struct {
+		cfg        QuotaScriptConfig
+		wantParent string
+		wantVolume string
+	}{
+		"no prefix (HelperPod)": {
+			cfg:        QuotaScriptConfig{ParentDir: "/data", VolumeDir: "pvc-abc"},
+			wantParent: "/data",
+			wantVolume: "/data/pvc-abc",
+		},
+		"with /host prefix (NodeDeployment)": {
+			cfg: QuotaScriptConfig{
+				ParentDir: "/var/openebs/local", VolumeDir: "pvc-abc",
+				HostPathPrefix: "/host",
+			},
+			wantParent: "/host/var/openebs/local",
+			wantVolume: "/host/var/openebs/local/pvc-abc",
+		},
+	}
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			parent, volume := tc.cfg.resolvePaths()
+			if parent != tc.wantParent {
+				t.Errorf("parent: got %q, want %q", parent, tc.wantParent)
+			}
+			if volume != tc.wantVolume {
+				t.Errorf("volume: got %q, want %q", volume, tc.wantVolume)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The quota setup and cleanup scripts are embedded in code and this makes it less testable and readable. This change moves it to its own file and embeds the script into the code at compile time.

## Pull Request template

**Why is this PR required? What issue does it fix?**:
The quota setup and cleanup scripts are embedded in code and this makes it less testable and readable. This change moves it to its own file and embeds the script into the code at compile time.

**What this PR does?**:
Moves the embedded shell scripts to its own file. The two apply and cleanup functions are triggered via different arguments.

**Does this PR require any upgrade changes?**:
It's a refactor, shouldn't required upgrade changes.

**If the changes in this PR are manually verified, list down the scenarios covered:**:
I'll update after I do more manual testing. Opening the PR for review in the mean time.

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 