### PR TITLE
fix(helper-pod): serialize quota project-ID allocation via flock

### DIFF
--- a/cmd/provisioner-localpv/app/helper_hostpath.go
+++ b/cmd/provisioner-localpv/app/helper_hostpath.go
@@ -217,7 +217,8 @@ func (p *Provisioner) createCleanupPod(ctx context.Context, pOpts *HelperPodOpti
 	cleanupScript := GenerateQuotaCleanupScript(QuotaScriptConfig{
 		ParentDir:      "/data",
 		VolumeDir:      config.volumeDir,
-		HostPathPrefix: "", // No prefix needed, /data is the mount point
+		HostPathPrefix: "",   // No prefix needed, /data is the mount point
+		UseHostLock:    true, // serialize against concurrent helper pods
 	})
 
 	config.pOpts.cmdsForPath = []string{"sh", "-c", cleanupScript}
@@ -280,7 +281,8 @@ func (p *Provisioner) createQuotaPod(ctx context.Context, pOpts *HelperPodOption
 		VolumeDir:      config.volumeDir,
 		SoftLimitGrace: config.pOpts.softLimitGrace,
 		HardLimitGrace: config.pOpts.hardLimitGrace,
-		HostPathPrefix: "", // No prefix needed, /data is the mount point
+		HostPathPrefix: "",   // No prefix needed, /data is the mount point
+		UseHostLock:    true, // serialize project-ID allocation
 	})
 
 	config.pOpts.cmdsForPath = []string{"sh", "-c", quotaScript}

--- a/cmd/provisioner-localpv/app/quota_scripts.go
+++ b/cmd/provisioner-localpv/app/quota_scripts.go
@@ -22,91 +22,119 @@ type QuotaScriptConfig struct {
 	// For HelperPod: use "" (parentDir is already mounted at /data)
 	// For DaemonSet: use "/host" (host root is mounted at /host)
 	HostPathPrefix string
+	// UseHostLock serializes the script via flock on a lockfile in the parent
+	// directory. Set for HelperPod mode; NodeDeployment relies on an in-process
+	// mutex instead.
+	UseHostLock bool
 }
 
-// GenerateQuotaApplyScript generates a shell script to apply filesystem quota
-// This script:
-// 1. Detects filesystem type (XFS or EXT4)
-// 2. Applies project quota with the specified limits
-func GenerateQuotaApplyScript(cfg QuotaScriptConfig) string {
-	// Extract numeric values for EXT4 setquota (it expects plain numbers in KB blocks, not with suffix)
-	extSoftLimit := strings.TrimSuffix(cfg.SoftLimitGrace, "k")
-	extHardLimit := strings.TrimSuffix(cfg.HardLimitGrace, "k")
-
-	// Build paths with optional prefix
-	parentPath := cfg.ParentDir
-	volumePath := filepath.Join(cfg.ParentDir, cfg.VolumeDir)
+// quotaPaths resolves the parent and volume paths from cfg, applying
+// HostPathPrefix when set (DaemonSet mode mounts host root at /host).
+func quotaPaths(cfg QuotaScriptConfig) (parent, volume string) {
+	parent = cfg.ParentDir
+	volume = filepath.Join(cfg.ParentDir, cfg.VolumeDir)
 	if cfg.HostPathPrefix != "" {
-		parentPath = filepath.Join(cfg.HostPathPrefix, cfg.ParentDir)
-		volumePath = filepath.Join(cfg.HostPathPrefix, cfg.ParentDir, cfg.VolumeDir)
+		parent = filepath.Join(cfg.HostPathPrefix, cfg.ParentDir)
+		volume = filepath.Join(cfg.HostPathPrefix, cfg.ParentDir, cfg.VolumeDir)
 	}
+	return parent, volume
+}
 
-	return fmt.Sprintf(`set -e
+// quotaLockPrologue returns a flock snippet on $PARENT_PATH/.openebs-quota.lock,
+// or "" when disabled. fd 9 is util-linux's conventional lock fd; the kernel
+// releases the lock when the shell exits.
+func quotaLockPrologue(enabled bool) string {
+	if !enabled {
+		return ""
+	}
+	return `# Serialize quota operations on this host.
+LOCKFILE="$PARENT_PATH/.openebs-quota.lock"
+LOCK_WAIT_SECONDS=60
+if ! command -v flock >/dev/null 2>&1; then
+    echo "flock(1) not found in PATH; cannot serialize quota operations on $LOCKFILE" >&2
+    exit 1
+fi
+# Pre-flight the lockfile path: exec 9>FILE aborts the shell on failure
+# (busybox ash does not honour ||), so probe with touch first.
+open_err=$(touch -- "$LOCKFILE" 2>&1) || {
+    echo "could not open lockfile $LOCKFILE for writing${open_err:+: $open_err}" >&2
+    exit 1
+}
+exec 9>"$LOCKFILE"
+flock_err=$(flock -w "$LOCK_WAIT_SECONDS" 9 2>&1) || {
+    echo "could not acquire flock on $LOCKFILE within ${LOCK_WAIT_SECONDS}s${flock_err:+: $flock_err}" >&2
+    exit 1
+}
+`
+}
 
-# Path to parent directory (mount point for quota commands)
+// GenerateQuotaApplyScript generates a shell script to apply filesystem quota.
+// It detects the filesystem type (XFS or EXT4) and applies a project quota
+// with the configured limits.
+func GenerateQuotaApplyScript(cfg QuotaScriptConfig) string {
+	parent, volume := quotaPaths(cfg)
+	// EXT4 setquota expects plain numbers (KB blocks), not the 'k' suffix.
+	extSoft := strings.TrimSuffix(cfg.SoftLimitGrace, "k")
+	extHard := strings.TrimSuffix(cfg.HardLimitGrace, "k")
+
+	header := fmt.Sprintf(`set -e
 PARENT_PATH="%s"
-# Path to volume directory
 VOLUME_PATH="%s"
+XFS_SOFT="%s"
+XFS_HARD="%s"
+EXT_SOFT="%s"
+EXT_HARD="%s"
+`, parent, volume, cfg.SoftLimitGrace, cfg.HardLimitGrace, extSoft, extHard)
 
-# Get filesystem type
-FS=$(stat -f -c %%T "$VOLUME_PATH")
+	return header + quotaLockPrologue(cfg.UseHostLock) + applyScriptBody
+}
+
+// GenerateQuotaCleanupScript generates a shell script to remove filesystem
+// quota and delete the volume directory.
+func GenerateQuotaCleanupScript(cfg QuotaScriptConfig) string {
+	parent, volume := quotaPaths(cfg)
+
+	header := fmt.Sprintf(`set -e
+PARENT_PATH="%s"
+VOLUME_PATH="%s"
+`, parent, volume)
+
+	return header + quotaLockPrologue(cfg.UseHostLock) + cleanupScriptBody
+}
+
+// applyScriptBody is the static body of the quota-apply script. All inputs
+// arrive via shell variables set by the generated header.
+const applyScriptBody = `
+FS=$(stat -f -c %T "$VOLUME_PATH")
 
 if [[ "$FS" == "xfs" ]]; then
-    # Get the next available project ID
+    # Allocate the next project ID and bind it to the volume.
     PID=$(xfs_quota -x -c 'report -h' "$PARENT_PATH" 2>/dev/null | tail -2 | awk 'NR==1{print substr ($1,2)}+0' || echo "0")
     PID=$((PID + 1))
-    # Set up project for the volume directory
     xfs_quota -x -c "project -s -p $VOLUME_PATH $PID" "$PARENT_PATH"
-    # Apply quota limits
-    xfs_quota -x -c "limit -p bsoft=%s bhard=%s $PID" "$PARENT_PATH"
+    xfs_quota -x -c "limit -p bsoft=$XFS_SOFT bhard=$XFS_HARD $PID" "$PARENT_PATH"
 elif [[ "$FS" == "ext2/ext3" ]]; then
     PID=$(repquota -P "$PARENT_PATH" 2>/dev/null | tail -3 | awk 'NR==1{print substr ($1,2)}+0' || echo "0")
     PID=$((PID + 1))
     chattr +P -p $PID "$VOLUME_PATH"
-    # setquota -P expects block limits as plain numbers (in KB blocks)
-    setquota -P $PID %s %s 0 0 "$PARENT_PATH"
+    # setquota -P expects plain numbers (KB blocks).
+    setquota -P $PID $EXT_SOFT $EXT_HARD 0 0 "$PARENT_PATH"
 else
     echo "Unsupported filesystem type: $FS"
     rm -rf "$VOLUME_PATH"
     exit 1
-fi`,
-		parentPath, volumePath,
-		cfg.SoftLimitGrace, cfg.HardLimitGrace, // xfs limits (with 'k' suffix)
-		extSoftLimit, extHardLimit, // ext quota limits (plain numbers in KB)
-	)
-}
+fi`
 
-// GenerateQuotaCleanupScript generates a shell script to remove filesystem quota and delete volume
-// This script:
-// 1. Detects filesystem type (XFS or EXT4)
-// 2. Removes project quota association
-// 3. Deletes the volume directory
-func GenerateQuotaCleanupScript(cfg QuotaScriptConfig) string {
-	// Build paths with optional prefix
-	parentPath := cfg.ParentDir
-	volumePath := filepath.Join(cfg.ParentDir, cfg.VolumeDir)
-	if cfg.HostPathPrefix != "" {
-		parentPath = filepath.Join(cfg.HostPathPrefix, cfg.ParentDir)
-		volumePath = filepath.Join(cfg.HostPathPrefix, cfg.ParentDir, cfg.VolumeDir)
-	}
-
-	return fmt.Sprintf(`set -e
-
-# Path to parent directory (mount point for quota commands)
-PARENT_PATH="%s"
-# Path to volume directory
-VOLUME_PATH="%s"
-
-# Get filesystem type
-FS=$(stat -f -c %%T "$VOLUME_PATH" 2>/dev/null || echo "unknown")
+// cleanupScriptBody is the static body of the quota-cleanup script. All
+// inputs arrive via shell variables set by the generated header.
+const cleanupScriptBody = `
+FS=$(stat -f -c %T "$VOLUME_PATH" 2>/dev/null || echo "unknown")
 
 if [[ "$FS" == "xfs" ]]; then
     ID=$(xfs_io -c stat "$VOLUME_PATH" 2>/dev/null | awk '/projid/{print $3}' | head -1)
     echo "projid=$ID"
     if [ -n "$ID" ] && [ "$ID" != "0" ]; then
-        # Remove projid binding
         xfs_io -c "chproj -R 0" "$VOLUME_PATH" 2>/dev/null || true
-        # Remove quota limit
         xfs_quota -x -c "limit -p bsoft=0 bhard=0 $ID" "$PARENT_PATH" 2>/dev/null || true
     fi
 elif [[ "$FS" == "ext2/ext3" ]]; then
@@ -116,7 +144,4 @@ elif [[ "$FS" == "ext2/ext3" ]]; then
     fi
 fi
 
-rm -rf "$VOLUME_PATH"`,
-		parentPath, volumePath,
-	)
-}
+rm -rf "$VOLUME_PATH"`


### PR DESCRIPTION
Two helper pods racing on the same node can read the same max projid from repquota/xfs_quota, increment to the same value, and bind two volumes to one quota bucket.

NodeDeployment mode serializes this with a Go mutex in LocalVolumeManager, but HelperPod mode runs each operation in a separate pod, so the lock has to live on the host. Wrap the generated apply and cleanup scripts in a subshell that holds an exclusive flock on <parentDir>/.openebs-quota.lock, gated by a new UseHostLock field on QuotaScriptConfig. The lock fd is scoped to the subshell, so it cannot collide with anything in the caller's environment, and the kernel releases the lock when the subshell exits.