### PR TITLE
feat: globaloverride for gaid and gakey

### DIFF
--- a/deploy/helm/charts/templates/daemonset.yaml
+++ b/deploy/helm/charts/templates/daemonset.yaml
@@ -109,11 +109,17 @@ spec:
           # leader-election; it is not managed by Helm.
         - name: OPENEBS_IO_ANALYTICS_LEASE
           value: {{ include "localpv.analyticsLease.name" . | quote }}
-        {{- if .Values.analytics.gaId }}
+        {{- if .Values.global.analytics.gaId }}
+        - name: GA_ID
+          value: {{ .Values.global.analytics.gaId | quote }}
+        {{- else if .Values.analytics.gaId }}
         - name: GA_ID
           value: {{ .Values.analytics.gaId | quote }}
         {{- end }}
-        {{- if .Values.analytics.gaKey }}
+        {{- if .Values.global.analytics.gaKey }}
+        - name: GA_KEY
+          value: {{ .Values.global.analytics.gaKey | quote }}
+        {{- else if .Values.analytics.gaKey }}
         - name: GA_KEY
           value: {{ .Values.analytics.gaKey | quote }}
         {{- end }}

--- a/deploy/helm/charts/templates/deployment.yaml
+++ b/deploy/helm/charts/templates/deployment.yaml
@@ -97,11 +97,17 @@ spec:
           # event unless the ConfigMap is deleted manually.
         - name: OPENEBS_IO_ANALYTICS_STATE_CM
           value: {{ include "localpv.analyticsStateCM.name" . | quote }}
-        {{- if .Values.analytics.gaId }}
+        {{- if .Values.global.analytics.gaId }}
+        - name: GA_ID
+          value: {{ .Values.global.analytics.gaId | quote }}
+        {{- else if .Values.analytics.gaId }}
         - name: GA_ID
           value: {{ .Values.analytics.gaId | quote }}
         {{- end }}
-        {{- if .Values.analytics.gaKey }}
+        {{- if .Values.global.analytics.gaKey }}
+        - name: GA_KEY
+          value: {{ .Values.global.analytics.gaKey | quote }}
+        {{- else if .Values.analytics.gaKey }}
         - name: GA_KEY
           value: {{ .Values.analytics.gaKey | quote }}
         {{- end }}

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -2,6 +2,15 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# NOTE: This option is required so that .global.imageRegistry works as an override
+#       for the local image registry values. By default, this option is set to false
+#       and that's to retain backwards compatibility with v4.4.0 where .global.imageRegistry
+#       was introduced as the default and the local options were overrides for the global default.
+#       The other .global options do not work this way, and they are all overrides for their
+#       respective options. If you're not upgrading from v4.4.0, you'll want to enable
+#       this option (set to 'true').
+globalImageRegistryOverride: false
+
 global:
   # Global override for container image registry (when `globalImageRegistryOverride` is set to true)
   imageRegistry: "docker.io"
@@ -13,9 +22,6 @@ global:
   analytics:
     # Global override for analytics
     enabled:
-
-# When set to true, the value of `global.imageRegistry` will override all image registry settings defined at local level
-globalImageRegistryOverride: false
 
 rbac:
   # rbac.create: `true` if rbac resources should be created


### PR DESCRIPTION
Why is this PR required? What issue does it fix?:
This PR implements Global Override behvaiour for gaid and gakey to be consistent with other local engine charts

What this PR does?:
This PR implements Global Override behvaiour for gaid and gakey to be consistent with other local engine charts

Does this PR require any upgrade changes?:
No

If the changes in this PR are manually verified, list down the scenarios covered::
did a helm template test on the chart manually

without anything set: no values are rendered
with global and local values set: global values win
with local values set: local is applied
Repeated the above procedure with `localpv.nodeDeployment.enabled=true` and observed similar results