### PR TITLE
docs(provisioner): fix mislabeled godoc on KeyNodeAffinityLabel

### DIFF
--- a/cmd/provisioner-localpv/app/config.go
+++ b/cmd/provisioner-localpv/app/config.go
@@ -33,9 +33,10 @@ const (
 	//        Instead use "KeyBlockDeviceSelectors" key
 	KeyBDTag = "BlockDeviceTag"
 
-	//KeyBlockDeviceSelectors defines the value for the Block Device selectors
-	//during bdc to bd claim configured via the StorageClass annotations.
+	//KeyNodeAffinityLabel defines the label key that should be
+	//used in the nodeAffinitySpec, configured via the StorageClass annotations.
 	// NOTE: This key should not be used as it is deprecated.
+	//        Instead use "KeyNodeAffinityLabels" key
 	KeyNodeAffinityLabel = "NodeAffinityLabel"
 
 	//KeyNodeAffinityLabels defines the label keys that should be


### PR DESCRIPTION

**Why is this PR required? What issue does it fix?**:

The godoc comment on the exported `KeyNodeAffinityLabel` constant in
`cmd/provisioner-localpv/app/config.go` was copy-pasted verbatim from the
`KeyBlockDeviceSelectors` block. As a result, `go doc` for this deprecated
node-affinity label key wrongly describes "the value for the Block Device
selectors during bdc to bd claim", which is an entirely unrelated key. This is
a documentation-only defect; there is no separate tracking issue.

**What this PR does?**:

Replaces the two mislabeled comment lines above `KeyNodeAffinityLabel` with an
accurate description (the label key used in the nodeAffinitySpec, configured via
the StorageClass annotations) and adds an `Instead use "KeyNodeAffinityLabels"
key` line, mirroring the deprecation NOTE style already used by `KeyBDTag`
directly above it. No code or behavior changes; the constant value is untouched.

```
-	//KeyBlockDeviceSelectors defines the value for the Block Device selectors
-	//during bdc to bd claim configured via the StorageClass annotations.
+	//KeyNodeAffinityLabel defines the label key that should be
+	//used in the nodeAffinitySpec, configured via the StorageClass annotations.
 	// NOTE: This key should not be used as it is deprecated.
+	//        Instead use "KeyNodeAffinityLabels" key
 	KeyNodeAffinityLabel = "NodeAffinityLabel"
```

**Does this PR require any upgrade changes?**:

No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

- `go doc ./cmd/provisioner-localpv/app KeyNodeAffinityLabel` now renders the
  node-affinity label key description with the correct deprecation pointer,
  instead of the block-device-selectors text.
- `gofmt -l cmd/provisioner-localpv/app/config.go` reports no changes.
- `go vet ./cmd/provisioner-localpv/app/...` passes.
- `go build ./cmd/provisioner-localpv/...` passes.

**Any additional information for your reviewer?** :

Documentation-only change to a single godoc comment; the constant, its value,
and all call sites are unchanged. The corrected text mirrors the existing
`KeyBDTag` deprecation NOTE two lines above and points to the plural
`KeyNodeAffinityLabels` replacement key that `GetNodeAffinityLabelKeys()`
consumes.

**Checklist:**
- [ ] Fixes #<issue number>  (no separate issue filed; documentation-only fix)
- [x] PR Title follows the convention of `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?  (n/a: comment-only godoc fix)
- [ ] Commit has unit tests  (n/a: comment-only, no logic changed)
- [ ] Commit has integration tests  (n/a: comment-only, no logic changed)
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:  (n/a)
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:  (n/a: in-code godoc only, not user docs)
