### PR TITLE
fix(charts): normalise registry sources to a trimmed string before resolution

### DIFF
--- a/deploy/helm/charts/templates/_helpers.tpl
+++ b/deploy/helm/charts/templates/_helpers.tpl
@@ -114,21 +114,40 @@ Usage:
 
 {{/*
 Creates the image URL ie registry/repository:tag
+
+Registry resolution is tolerant of upgrades from chart versions that predate
+.global.imageRegistry (for example v4.1.4, which had no `global` block and left
+`registry` unset). Each registry source is normalised to a trimmed string
+(an unset/null value becomes "") before precedence is applied, so a stripped
+registry - e.g. under `helm upgrade --reuse-values` - no longer fails with
+"invalid value; expected string".
+
+  - override (globalImageRegistryOverride=true): .global.imageRegistry takes
+    precedence over the image-local registry, falling back to the local one
+    when the global registry is unset.
+  - default  (globalImageRegistryOverride=false): the image-local registry
+    takes precedence, falling back to .global.imageRegistry when the local
+    one is unset (retains v4.4.0 behaviour where the global was the default).
+
+If neither registry resolves (both unset), the image defaults to the docker.io
+registry - matching the chart's default .global.imageRegistry - so upgrades that
+dropped the value still render a fully-qualified reference rather than an
+unprefixed one.
 */}}
 {{- define "localpv.common.image" -}}
-{{ $registryName := "" }}
-{{- if .override -}}
-{{- $registryName = default .imageRoot.registry .global.imageRegistry | trimSuffix "/" -}}
-{{- else -}}
-{{- $registryName = default .global.imageRegistry .imageRoot.registry | trimSuffix "/" -}}
-{{- end -}}
-{{- $repositoryName := .imageRoot.repository -}}
-{{- $termination := .imageRoot.tag | toString -}}
-{{- if $registryName }}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $termination -}}
-{{- else -}}
-    {{- printf "%s:%s"  $repositoryName $termination -}}
-{{- end -}}
+  {{- $global := .global | default dict -}}
+  {{- $localRegistry := .imageRoot.registry | default "" | toString | trimSuffix "/" -}}
+  {{- $globalRegistry := $global.imageRegistry | default "" | toString | trimSuffix "/" -}}
+  {{- $registryName := "" -}}
+  {{- if .override -}}
+    {{- $registryName = $globalRegistry | default $localRegistry -}}
+  {{- else -}}
+    {{- $registryName = $localRegistry | default $globalRegistry -}}
+  {{- end -}}
+  {{- $registryName = $registryName | default "docker.io" -}}
+  {{- $repositoryName := .imageRoot.repository -}}
+  {{- $termination := .imageRoot.tag | toString -}}
+  {{- printf "%s/%s:%s" $registryName $repositoryName $termination -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
In `deploy/helm/charts/templates/_helpers.tpl`, the `localpv.common.image` function piped `default .imageRoot.registry .global.imageRegistry` straight into `trimSuffix /`. `trimSuffix` requires a `string` argument, but when **both** the image-local `registry` and `.global.imageRegistry` are absent/null, `default` returns a nil value → `invalid value; expected string`.

That is precisely the v4.1.4 state: it had **no `global` block** and left `localpv.image.registry`/`helperPod.image.registry` unset. On `helm upgrade` the old release's values are carried over without merging the new chart defaults, so neither registry is a string and the render crashes. Upgrades from v4.4.0+ escaped this only because `global.imageRegistry: docker.io` was already a carried-over string.